### PR TITLE
Ability to enable basic-auth for POST, PUT and DELETE requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ services:
       - ./data/files/lpdc:/data
 ```
 
+## Basic auth configuration
+
+You can configure basic auth for the POST, PUT and DELETE endpoints of this service using the following environment variables:
+- `ENABLE_AUTH`: whether to enable basic auth or not (default: `false`)
+- `AUTH_USERNAME`: the username to use (default: `username`)
+- `AUTH_PASSWORD`: the password to use (default: `password`)
+
 # Public Services
 
 Public service templates, also called Conceptual Public Services (after this called Template) exist in the database under the type `<http://lblod.data.gift/vocabularies/lpdc-ipdc/ConceptualPublicService>`. When a user creates a new public service in the frontend, this service will create a new public-service from a template only changing the type to `<http://purl.org/vocab/cpsv#PublicService>`.

--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ import { ENABLE_AUTH, AUTH_USERNAME, AUTH_PASSWORD} from './config';
 
 app.use(bodyparser.json());
 
-app.use((req, res, next) => {
+const validateUser = (req, res, next) => {
   if (ENABLE_AUTH) {
     if (req.headers.authorization?.startsWith('Basic ')) {
       const b64value = req.headers.authorization.split(' ')[1];
@@ -22,14 +22,14 @@ app.use((req, res, next) => {
     return res.status(401).send('Authentication failed.');
   }
   return next();
-});
+};
 
 app.get('/', function(req, res) {
   const message = `Hey there, you have reached the lpdc-management-service! Seems like I'm doing just fine, have a nice day! :)`;
   res.send(message);
 });
 
-app.post('/public-services/', async function(req, res) {
+app.post('/public-services/', validateUser, async function(req, res) {
   const body = req.body;
   const publicServiceId = body?.data?.relationships?.["concept"]?.data?.id;
 
@@ -102,7 +102,7 @@ app.get('/semantic-forms/:publicServiceId/form/:formId', async function(req, res
   }
 });
 
-app.put('/semantic-forms/:publicServiceId/form/:formId', async function(req, res) {
+app.put('/semantic-forms/:publicServiceId/form/:formId', validateUser, async function(req, res) {
   const delta = req.body;
 
   try {
@@ -121,7 +121,7 @@ app.put('/semantic-forms/:publicServiceId/form/:formId', async function(req, res
   }
 });
 
-app.delete('/public-services/:publicServiceId', async function(req, res) {
+app.delete('/public-services/:publicServiceId', validateUser, async function(req, res) {
   const publicServiceId = req.params.publicServiceId;
   try {
     await deleteForm(publicServiceId);

--- a/app.js
+++ b/app.js
@@ -4,7 +4,25 @@ import { createForm, createEmptyForm } from './lib/createForm';
 import { retrieveForm } from './lib/retrieveForm';
 import { updateForm } from './lib/updateForm';
 import { deleteForm } from './lib/deleteForm';
+import { ENABLE_AUTH, AUTH_USERNAME, AUTH_PASSWORD} from './config';
+
 app.use(bodyparser.json());
+
+app.use((req, res, next) => {
+  if (ENABLE_AUTH) {
+    if (req.headers.authorization?.startsWith('Basic ')) {
+      const b64value = req.headers.authorization.split(' ')[1];
+      const [username, password] = Buffer.from(b64value, 'base64')
+        .toString()
+        .split(':');
+      if (username === AUTH_USERNAME && password === AUTH_PASSWORD) {
+        return next();
+      }
+    }
+    return res.status(401).send('Authentication failed.');
+  }
+  return next();
+});
 
 app.get('/', function(req, res) {
   const message = `Hey there, you have reached the lpdc-management-service! Seems like I'm doing just fine, have a nice day! :)`;

--- a/config.js
+++ b/config.js
@@ -31,10 +31,17 @@ const PREFIXES = `
   PREFIX ps: <http://vocab.belgif.be/ns/publicservice#>
   PREFIX locn: <http://www.w3.org/ns/locn>`;
 
+const ENABLE_AUTH = process.env.ENABLE_AUTH === "true" ? true : false;
+const AUTH_USERNAME = process.env.AUTH_USERNAME || "username";
+const AUTH_PASSWORD = process.env.AUTH_PASSWORD || "password";
+
 
 export {
   FORM_STATUS_CONCEPT,
   APPLICATION_GRAPH,
   FORM_MAPPING,
-  PREFIXES
+  PREFIXES,
+  ENABLE_AUTH,
+  AUTH_USERNAME,
+  AUTH_PASSWORD
 };


### PR DESCRIPTION
This PR allows for enabling basic auth on POST, PUT and DELETE requests.
You can configure it with the ENABLE_AUTH, AUTH_USERNAME and AUTH_PASSWORD environment variables.
By default, basic auth is disabled.

https://binnenland.atlassian.net/jira/software/c/projects/DL/boards/2?modal=detail&selectedIssue=DL-4031