### PR TITLE
Add support for fetching form data for conceptual public services

### DIFF
--- a/lib/retrieveForm.js
+++ b/lib/retrieveForm.js
@@ -22,24 +22,34 @@ export async function retrieveForm(publicServiceId, formId, bestuurseenheid) {
   const form = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/form.ttl`, 'utf8');
   const metaFile = fse.readJsonSync(`/config/${FORM_MAPPING[formId]}/form.json`);
   const schemes = metaFile.meta.schemes;
-  const serviceUri = await serviceUriForId(publicServiceId);
+
+  let isConceptualPublicService = false;
+  let serviceUri = await serviceUriForId(publicServiceId);
 
   if(!serviceUri) {
-    throw `Service URI not found for id ${publicServiceId}`;
+    serviceUri = await serviceUriForId(publicServiceId, 'lpdcExt:ConceptualPublicService');
+
+    if (serviceUri) {
+      isConceptualPublicService = true;
+    } else {
+      throw `Service URI not found for id ${publicServiceId}`;
+    }
   }
+  
+  const type = isConceptualPublicService ? 'lpdcExt:ConceptualPublicService' : 'cpsv:PublicService';
 
   const results = [];
-  results.push(await loadEvidences(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadRequirements(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadOnlineProcedureRules(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadRules(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadCosts(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadFinancialAdvantages(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadContactPointsAddresses(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadContactPoints(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadWebsites(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadPublicService(serviceUri, { type: 'cpsv:PublicService' }));
-  results.push(await loadAttachments(serviceUri, { type: 'cpsv:PublicService' }));
+  results.push(await loadEvidences(serviceUri, { type }));
+  results.push(await loadRequirements(serviceUri, { type }));
+  results.push(await loadOnlineProcedureRules(serviceUri, { type }));
+  results.push(await loadRules(serviceUri, { type }));
+  results.push(await loadCosts(serviceUri, { type }));
+  results.push(await loadFinancialAdvantages(serviceUri, { type }));
+  results.push(await loadContactPointsAddresses(serviceUri, { type }));
+  results.push(await loadContactPoints(serviceUri, { type }));
+  results.push(await loadWebsites(serviceUri, { type }));
+  results.push(await loadPublicService(serviceUri, { type }));
+  results.push(await loadAttachments(serviceUri, { type }));
 
   const sourceBindings = results
         .reduce((acc, b) => [...acc, ...b]);


### PR DESCRIPTION
This allows us to use the same endpoint for fetching the conceptual public service forms.