### PR TITLE
Add productID as part of loading a public service

### DIFF
--- a/lib/commonQueries.js
+++ b/lib/commonQueries.js
@@ -404,6 +404,7 @@ export async function loadPublicService(service, { graph, type, validTypes, incl
               dct:modified
               pav:createdBy
               dct:source
+              schema:productID
             }
 
             GRAPH ${sparqlEscapeUri(graph)} {


### PR DESCRIPTION
Load the productID of a public service alongside the public service's other fields.