### PR TITLE
Return the `sh:order` predicate for all listings when fetching form data

### DIFF
--- a/config.js
+++ b/config.js
@@ -42,6 +42,7 @@ const PREFIXES = `
   PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
   PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
   PREFIX as: <https://www.w3.org/ns/activitystreams#>
+  PREFIX sh: <http://www.w3.org/ns/shacl#>
 `;
 
 

--- a/lib/commonQueries.js
+++ b/lib/commonQueries.js
@@ -20,6 +20,7 @@ export async function loadEvidences(serviceUri, { graph, type, includeUuid, sudo
           dct:description
           dct:title
           dct:source
+          sh:order
         }
 
         GRAPH ${sparqlEscapeUri(graph)} {
@@ -55,6 +56,7 @@ export async function loadRequirements(service, { graph, type, includeUuid, sudo
           dct:title
           m8g:hasSupportingEvidence
           dct:source
+          sh:order
         }
 
         GRAPH ${sparqlEscapeUri(graph)} {
@@ -121,6 +123,7 @@ export async function loadRules(service, { graph, type, includeUuid, sudo } = {}
           dct:title
           lpdcExt:hasWebsite
           dct:source
+          sh:order
         }
 
         GRAPH ${sparqlEscapeUri(graph)} {
@@ -154,6 +157,7 @@ export async function loadCosts(service, { graph, type, includeUuid, sudo } = {}
           dct:description
           dct:title
           dct:source
+          sh:order
         }
 
         GRAPH ${sparqlEscapeUri(graph)} {
@@ -187,6 +191,7 @@ export async function loadFinancialAdvantages(service, { graph, type, includeUui
           dct:description
           dct:title
           dct:source
+          sh:order
         }
 
         GRAPH ${sparqlEscapeUri(graph)} {
@@ -251,6 +256,7 @@ export async function loadContactPointsAddresses(service, { graph, type, include
           adres:gemeentenaam
           adres:land
           dct:source
+          sh:order
         }
 
         GRAPH ${sparqlEscapeUri(graph)} {
@@ -287,6 +293,7 @@ export async function loadContactPoints(service, { graph, type, includeUuid, sud
          schema:openingHours
          schema:url
          dct:source
+         sh:order
         }
 
         GRAPH ${sparqlEscapeUri(graph)} {
@@ -355,6 +362,7 @@ export async function loadWebsites(service, { graph, type, includeUuid, sudo } =
          dct:title
          schema:url
          dct:source
+         sh:order
         }
 
         GRAPH ${sparqlEscapeUri(graph)} {


### PR DESCRIPTION
This makes it possible to show the listing items in the order they were created.

This PR complements the work done in https://github.com/lblod/ember-submission-form-fields/pull/120.

To test:
- link the ember-submission-form-fields branch into frontend-loket
- create a new (blank) concept
- create multiple listing items (for example "Kosten")
- save the form
- refresh the page
- check that the order is still the same as before (or check the response to see if it includes `sh:order` predicates