### PR TITLE
Return `sh:order` for "OnlineProcedureRules"

### DIFF
--- a/lib/commonQueries.js
+++ b/lib/commonQueries.js
@@ -90,6 +90,7 @@ export async function loadOnlineProcedureRules(service, { graph, type, includeUu
           dct:title
           schema:url
           dct:source
+          sh:order
         }
 
         GRAPH ${sparqlEscapeUri(graph)} {


### PR DESCRIPTION
It seems I forgot this one in #26 so the websites were still displayed in the wrong order.