### PR TITLE
Generate runtime concept schemes for all bestuurseenheden

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,10 +44,9 @@ app.post('/delta', async function( req, res ) {
 app.post('/semantic-forms/:publicServiceId/submit', async function(req, res) {
 
   const publicServiceId = req.params["publicServiceId"];
-  const sessionUri = req.headers['mu-session-id'];
+  
   try {
-    const bestuurseenheidData = await bestuurseenheidForSession(sessionUri);
-    const response = await validateService(publicServiceId, bestuurseenheidData.bestuurseenheid);
+    const response = await validateService(publicServiceId);
 
     if(response.errors.length) {
       return res.status(400).json({
@@ -126,11 +125,9 @@ app.post('/public-services/', async function(req, res) {
 app.get('/semantic-forms/:publicServiceId/form/:formId', async function(req, res) {
   const publicServiceId = req.params["publicServiceId"];
   const formId = req.params["formId"];
-  const sessionUri = req.headers['mu-session-id'];
 
   try {
-    const bestuurseenheidData = await bestuurseenheidForSession(sessionUri);
-    const bundle = await retrieveForm(publicServiceId, formId, bestuurseenheidData.bestuurseenheid);
+    const bundle = await retrieveForm(publicServiceId, formId);
 
     return res.status(200).json(bundle);
   } catch (e) {

--- a/lib/retrieveForm.js
+++ b/lib/retrieveForm.js
@@ -18,7 +18,7 @@ import { loadEvidences,
          serviceUriForId
        } from './commonQueries';
 
-export async function retrieveForm(publicServiceId, formId, bestuurseenheid) {
+export async function retrieveForm(publicServiceId, formId) {
   const form = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/form.ttl`, 'utf8');
   const metaFile = fse.readJsonSync(`/config/${FORM_MAPPING[formId]}/form.json`);
   const schemes = metaFile.meta.schemes;
@@ -68,7 +68,7 @@ export async function retrieveForm(publicServiceId, formId, bestuurseenheid) {
     }
   `;
 
-  const tailoredSchemes = await generateRuntimeConceptSchemes(bestuurseenheid);
+  const tailoredSchemes = await generateRuntimeConceptSchemes();
   const storeSchemes = await querySudo(schemesQuery);
   const meta = [ ...bindingsToNT(storeSchemes.results.bindings), ...tailoredSchemes ].join("\r\n");
   const source = bindingsToNT(sourceBindings).join("\r\n");
@@ -77,30 +77,32 @@ export async function retrieveForm(publicServiceId, formId, bestuurseenheid) {
 }
 
 /*
- * Some codelists need to be generated at runtime, since the content
- * varies in function of the bestuurseenheid who logged in.
- * Now it is uitvoerende and bevoegde overheid
+ * Generate codelists for all bestuurseenheden at runtime for the
+ * "Uitvoerende Overheid" and "Bevoegde Overheid" fields in the
+ * "Eigenschappen" tab of an LPDC public service form.
+ * For example, if "Gemeente Aalter" is the current user,
+ * they will be able to add the various"Gemeenten", "OCMW" and
+ * other organizations within app-digitaal-loket.
  */
-async function generateRuntimeConceptSchemes(bestuurseenheid) {
+async function generateRuntimeConceptSchemes() {
   //spliting in two because faster
   const tailoredConceptQ = `
     ${PREFIXES}
+
     CONSTRUCT {
-       ?bestuurseenheid a skos:Concept;
-         skos:inScheme <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties/tailored>;
-         skos:prefLabel ?newLabel.
+      ?bestuurseenheid a skos:Concept ;
+        skos:inScheme <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties/tailored> ;
+        skos:prefLabel ?newLabel .
     }
     WHERE {
-        BIND(${sparqlEscapeUri(bestuurseenheid)} as ?bestuurseenheid)
-        ?bestuurseenheid a besluit:Bestuurseenheid;
-        skos:prefLabel ?bestuurseenheidLabel.
+      ?bestuurseenheid a besluit:Bestuurseenheid ;
+        skos:prefLabel ?bestuurseenheidLabel .
 
-      ?bestuurseenheid besluit:classificatie ?bestuurseenheidClassificatie.
-        ?bestuurseenheidClassificatie skos:prefLabel ?bestuurseenheidClassificatieLabel .
+      ?bestuurseenheid besluit:classificatie ?bestuurseenheidClassificatie .
+      ?bestuurseenheidClassificatie skos:prefLabel ?bestuurseenheidClassificatieLabel .
 
       BIND(CONCAT(?bestuurseenheidLabel, " (", ?bestuurseenheidClassificatieLabel, ")") as ?newLabel)
     }
-
   `;
 
   let tailoredConcept = await querySudo(tailoredConceptQ);
@@ -108,15 +110,16 @@ async function generateRuntimeConceptSchemes(bestuurseenheid) {
 
   const baseSchemeQ = `
     ${PREFIXES}
+
     CONSTRUCT {
-       ?s ?p ?o;
-         skos:inScheme <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties/tailored>.
+      ?s ?p ?o ;
+        skos:inScheme <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties/tailored> .
     }
     WHERE {
-     ?s a skos:Concept;
-       skos:inScheme dvcs:IPDCOrganisaties;
-       rdfs:seeAlso <https://wegwijs.vlaanderen.be>;
-       ?p ?o.
+      ?s a skos:Concept ;
+        skos:inScheme dvcs:IPDCOrganisaties ;
+        rdfs:seeAlso <https://wegwijs.vlaanderen.be> ;
+        ?p ?o .
     }
   `;
 

--- a/lib/validateService.js
+++ b/lib/validateService.js
@@ -8,13 +8,13 @@ const FORM = new rdflib.Namespace('http://lblod.data.gift/vocabularies/forms/');
 const RDF = new rdflib.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
 const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
 
-export async function validateService(publicServiceId, bestuurseenheid){
+export async function validateService(publicServiceId){
   const formIds = Object.keys(FORM_MAPPING);
   const forms = [];
 
   for (const id of formIds) {
     try {
-      const form = await retrieveForm(publicServiceId, id, bestuurseenheid);
+      const form = await retrieveForm(publicServiceId, id);
       forms.push({
         type: FORM_MAPPING[id],
         form: form,


### PR DESCRIPTION
(Addresses DL-4913) Allows LPDC users to add different types of organizations (Gemeenten, OCMW, Autonoom Provinciebedrijf, Autonoom Gemeentebedrijf, etc.) in the "Uitvoerende Overheid" and "Bevoegde Overheid" fields.

To test:
* Add the below configuration to `docker-compose.override.yml` in your local `app-digitaal-loket` repo.
```
lpdc-management:
    ports:
      - 9229:9229
    environment:
      NODE_ENV: "development"
    volumes:
      - ./config/lpdc-management:/config
      - ./data/files/lpdc:/data
      - </path/to/>lpdc-management-service/:/app/
```
* Log in as any organization
* Go to the `Producten- en dienstencatalogus` module and add an existing/new service
* Go to the `Eigenschappen` tab of the service form and find the "Bevoegde overheid" and "Uitvoerende overheid" fields
* Searching in these fields should yield all types of organizations (e.g., <Name of organization> (Gemeente), <Name of organization> (OCMW), <Name of organization> (Autonoom gemeentebedrijf), etc.)