### PR TITLE
Fix the spatial fallback behavior for the empty forms

### DIFF
--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -34,7 +34,7 @@ export async function createEmptyForm(bestuurseenheid) {
         dct:modified ${sparqlEscapeDateTime(now)} ;
         mu:uuid """${publicServiceId}""" ;
         adms:status <http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd> ;
-        ${spatialsPreparedStatement.length ? spatialsPreparedStatement : 'dct:spatial ?spatial;'}
+        ${spatialsPreparedStatement.length ? spatialsPreparedStatement : ''}
         pav:createdBy ${sparqlEscapeUri(bestuurseenheid)};
         m8g:hasCompetentAuthority ${sparqlEscapeUri(bestuurseenheid)};
         lpdcExt:hasExecutingAuthority ${sparqlEscapeUri(bestuurseenheid)}.


### PR DESCRIPTION
It seems the fallback behavior was incorrect and produced an incorrect query which triggers an exception. We now use the same fallback as the regular form creating flow.

This fixes an issue where creating empty forms didn't work if the bestuurseenheid of the current user doesn't have a spatial.

DL-5050