### PR TITLE
Load the correct form based on the publication channel value

### DIFF
--- a/lib/retrieveForm.js
+++ b/lib/retrieveForm.js
@@ -68,8 +68,8 @@ export async function retrieveForm(publicServiceId, formId) {
   // If a user chooses "YourEurope" as their publication channel, load 
   // the relevants snippets into the content form that render the English fields obligatory.
   if (FORM_MAPPING[formId] === "content" && isYourEurope) {
-    const english_requirement_form_snippets = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/add-english-requirement.ttl`, 'utf8');
-    form += english_requirement_form_snippets;
+    const englishRequirementFormSnippets = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/add-english-requirement.ttl`, 'utf8');
+    form += englishRequirementFormSnippets;
   }
 
   const schemesQuery = `

--- a/lib/retrieveForm.js
+++ b/lib/retrieveForm.js
@@ -19,10 +19,6 @@ import { loadEvidences,
        } from './commonQueries';
 
 export async function retrieveForm(publicServiceId, formId) {
-  const form = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/form.ttl`, 'utf8');
-  const metaFile = fse.readJsonSync(`/config/${FORM_MAPPING[formId]}/form.json`);
-  const schemes = metaFile.meta.schemes;
-
   let isConceptualPublicService = false;
   let serviceUri = await serviceUriForId(publicServiceId);
 
@@ -54,6 +50,31 @@ export async function retrieveForm(publicServiceId, formId) {
   const sourceBindings = results
         .reduce((acc, b) => [...acc, ...b]);
 
+  let form, metaFile;
+
+  // Check whether a user chose "YourEurope" as their publication channel
+  const publicationChannelQuery = `
+    ${PREFIXES}
+
+    ASK {
+      ${sparqlEscapeUri(serviceUri)} a ${type} ;
+        <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#publicationMedium> <https://productencatalogus.data.vlaanderen.be/id/concept/PublicatieKanaal/YourEurope> .
+    }
+  `;
+  let isYourEurope = (await querySudo(publicationChannelQuery)).boolean;
+  
+  // If a user chooses "YourEurope" as their publication channel,
+  // load the regular content and characteristics forms. Else, load
+  // the forms that do not have validation on English fields.
+  if (isYourEurope === true) {
+    form = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/form.ttl`, 'utf8');
+    metaFile = fse.readJsonSync(`/config/${FORM_MAPPING[formId]}/form.json`);
+  } else {
+    form = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/form-without-english-requirement.ttl`, 'utf8');
+    metaFile = fse.readJsonSync(`/config/${FORM_MAPPING[formId]}/form-without-english-requirement.json`);
+  }
+
+  const schemes = metaFile.meta.schemes;
 
   const schemesQuery = `
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -72,7 +93,7 @@ export async function retrieveForm(publicServiceId, formId) {
   const storeSchemes = await querySudo(schemesQuery);
   const meta = [ ...bindingsToNT(storeSchemes.results.bindings), ...tailoredSchemes ].join("\r\n");
   const source = bindingsToNT(sourceBindings).join("\r\n");
-
+  
   return { form, meta, source, serviceUri };
 }
 

--- a/lib/retrieveForm.js
+++ b/lib/retrieveForm.js
@@ -19,6 +19,10 @@ import { loadEvidences,
        } from './commonQueries';
 
 export async function retrieveForm(publicServiceId, formId) {
+  let form = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/form.ttl`, 'utf8');
+  const metaFile = fse.readJsonSync(`/config/${FORM_MAPPING[formId]}/form.json`);
+  const schemes = metaFile.meta.schemes;
+
   let isConceptualPublicService = false;
   let serviceUri = await serviceUriForId(publicServiceId);
 
@@ -50,8 +54,6 @@ export async function retrieveForm(publicServiceId, formId) {
   const sourceBindings = results
         .reduce((acc, b) => [...acc, ...b]);
 
-  let form, metaFile;
-
   // Check whether a user chose "YourEurope" as their publication channel
   const publicationChannelQuery = `
     ${PREFIXES}
@@ -62,19 +64,13 @@ export async function retrieveForm(publicServiceId, formId) {
     }
   `;
   let isYourEurope = (await querySudo(publicationChannelQuery)).boolean;
-  
-  // If a user chooses "YourEurope" as their publication channel,
-  // load the regular content and characteristics forms. Else, load
-  // the forms that do not have validation on English fields.
-  if (isYourEurope === true) {
-    form = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/form.ttl`, 'utf8');
-    metaFile = fse.readJsonSync(`/config/${FORM_MAPPING[formId]}/form.json`);
-  } else {
-    form = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/form-without-english-requirement.ttl`, 'utf8');
-    metaFile = fse.readJsonSync(`/config/${FORM_MAPPING[formId]}/form-without-english-requirement.json`);
+  debugger;
+  // If a user chooses "YourEurope" as their publication channel, load 
+  // the relevants snippets into the content form that render the English fields obligatory.
+  if (FORM_MAPPING[formId] === "content" && isYourEurope === true) {
+    const english_requirement_form_snippets = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/add-english-requirement.ttl`, 'utf8');
+    form += english_requirement_form_snippets;
   }
-
-  const schemes = metaFile.meta.schemes;
 
   const schemesQuery = `
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/lib/retrieveForm.js
+++ b/lib/retrieveForm.js
@@ -64,10 +64,10 @@ export async function retrieveForm(publicServiceId, formId) {
     }
   `;
   let isYourEurope = (await querySudo(publicationChannelQuery)).boolean;
-  debugger;
+
   // If a user chooses "YourEurope" as their publication channel, load 
   // the relevants snippets into the content form that render the English fields obligatory.
-  if (FORM_MAPPING[formId] === "content" && isYourEurope === true) {
+  if (FORM_MAPPING[formId] === "content" && isYourEurope) {
     const english_requirement_form_snippets = fs.readFileSync(`/config/${FORM_MAPPING[formId]}/add-english-requirement.ttl`, 'utf8');
     form += english_requirement_form_snippets;
   }

--- a/lib/retrieveForm.js
+++ b/lib/retrieveForm.js
@@ -89,7 +89,7 @@ export async function retrieveForm(publicServiceId, formId) {
   const storeSchemes = await querySudo(schemesQuery);
   const meta = [ ...bindingsToNT(storeSchemes.results.bindings), ...tailoredSchemes ].join("\r\n");
   const source = bindingsToNT(sourceBindings).join("\r\n");
-  
+
   return { form, meta, source, serviceUri };
 }
 


### PR DESCRIPTION
(Addresses DL-3983) Removes the English translation requirements when `YourEurope` is not chosen as the publication channel in the `Eigenschappen` tab in a LPDC form.

This is to be tested in tandem with the following PR for `app-digitaal-loket`: https://github.com/lblod/app-digitaal-loket/pull/400.