### PR TITLE
Implement the concept label and filtering functionality

### DIFF
--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -164,6 +164,7 @@ export async function createForm(conceptId, bestuurseenheid) {
   `;
 
   await update(extraDataQuery);
+  await updateConceptDisplayConfig(conceptUri);
 
   return {
     uuid: newServiceUuid,
@@ -277,4 +278,32 @@ async function getSpatialForBestuurseenheid(bestuurseenheid) {
   const results = (await query(queryStr)).results.bindings;
 
   return results.map(r => r.spatial.value);
+}
+
+async function updateConceptDisplayConfig(conceptUri) {
+  const updateConceptDisplayConfigQuery = `
+    ${PREFIXES}
+
+    DELETE {
+      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+        ?config lpdcExt:conceptIsNew ?oldIsNew ;
+          lpdcExt:conceptInstantiated ?oldIsInstantiated .
+      }
+    }
+    INSERT {
+      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+        ?config lpdcExt:conceptIsNew "false"^^xsd:boolean ;
+          lpdcExt:conceptInstantiated "true"^^xsd:boolean .
+      }
+    }
+    WHERE {
+      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+        ${sparqlEscapeUri(conceptUri)} lpdcExt:hasConceptDisplayConfiguration ?config .
+        ?config lpdcExt:conceptIsNew ?oldIsNew ;
+          lpdcExt:conceptInstantiated ?oldIsInstantiated .
+      }
+    }
+  `;
+
+  await update(updateConceptDisplayConfigQuery);
 }

--- a/lib/deleteForm.js
+++ b/lib/deleteForm.js
@@ -1,4 +1,4 @@
-import { sparqlEscapeString, sparqlEscapeUri, sparqlEscapeDateTime, update } from 'mu';
+import { sparqlEscapeString, sparqlEscapeUri, sparqlEscapeDateTime, update, query } from 'mu';
 import { APPLICATION_GRAPH, PREFIXES } from '../config';
 import { bindingsToNT } from '../utils/bindingsToNT';
 import { loadEvidences,
@@ -24,6 +24,9 @@ export async function deleteForm(serviceId, sessionUri) {
   if(!serviceUri) {
     throw `Service URI not found for id ${serviceId}`;
   }
+
+  const conceptUri = await conceptUriForService(serviceUri);
+  const hadConcept = Boolean(conceptUri);
 
   const results = [];
 
@@ -83,4 +86,60 @@ export async function deleteForm(serviceId, sessionUri) {
   `;
   await update(insertTombstoneQuery);
 
+  if (hadConcept && !(await conceptHasInstances(conceptUri))) {
+    await removeInstantiatedFlag(conceptUri);
+  }
+}
+
+async function conceptUriForService(serviceUri) {
+  return (await query(`
+      ${PREFIXES}
+
+      SELECT DISTINCT ?concept
+      WHERE {
+        BIND(${sparqlEscapeUri(serviceUri)} as ?service)
+        ?service a cpsv:PublicService ;
+          dct:source ?concept.
+      }
+      LIMIT 1
+    `)).results.bindings[0]?.concept?.value;
+}
+
+async function conceptHasInstances(conceptUri) {
+  const conceptHasInstancesQuery = `
+    ${PREFIXES}
+    ASK WHERE {
+      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+        ?instance a cpsv:PublicService ;
+          dct:source ${sparqlEscapeUri(conceptUri)} .
+      }
+    }
+  `;
+
+  return (await query(conceptHasInstancesQuery)).boolean;
+}
+
+async function removeInstantiatedFlag(conceptUri) {
+  const removeInstantiatedFlagQuery = `
+    ${PREFIXES}
+
+    DELETE {
+      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+        ?config lpdcExt:conceptInstantiated ?oldIsInstantiated .
+      }
+    }
+    INSERT {
+      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+        ?config lpdcExt:conceptInstantiated "false"^^xsd:boolean .
+      }
+    }
+    WHERE {
+      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+        ${sparqlEscapeUri(conceptUri)} lpdcExt:hasConceptDisplayConfiguration ?config .
+        ?config lpdcExt:conceptInstantiated ?oldIsInstantiated .
+      }
+    }
+  `;
+
+  await update(removeInstantiatedFlagQuery);
 }

--- a/lib/postProcessLdesConceptualService.js
+++ b/lib/postProcessLdesConceptualService.js
@@ -44,6 +44,7 @@ export async function processLdesDelta(delta) {
       await updateNewLdesVersion(entry.graph.value, entry.subject.value, entry.object.value);
       await updatedVersionInformation(entry.subject.value, entry.object.value);
       await flagInstancesModifiedConcept(entry.graph.value, entry.subject.value, entry.object.value);
+      await ensureConceptDisplayConfigs(entry.graph.value, entry.subject.value, entry.object.value);
     } catch (e) {
       console.error(`Error processing: ${JSON.stringify(entry)}`);
       console.error(e);
@@ -391,4 +392,53 @@ async function flagInstancesModifiedConcept(vGraph, vService, service) {
   `;
 
   await updateSudo(updateQueryStr);
+}
+
+async function ensureConceptDisplayConfigs(versionedServiceGraph, versionedService, conceptualService) {
+  // This list limits the type of bestuurseenheden for which the config objects will be created.
+  // Only types that have access to the LPDC module should be added here.
+  const ALLOWED_BESTUURSEENHEID_CLASSIFICATIONS = [
+    'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000', // Provincie
+    'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001' // Gemeente
+  ];
+
+  const insertConfigsQuery = `
+    ${PREFIXES}
+    
+    INSERT {
+      GRAPH ?graph {
+        ?concept lpdcExt:hasConceptDisplayConfiguration ?configUri .
+        ?configUri a lpdcExt:ConceptDisplayConfiguration ;
+          mu:uuid ?configId ;
+          lpdcExt:conceptIsNew "true"^^xsd:boolean ;
+          lpdcExt:conceptInstantiated "false"^^xsd:boolean ;
+          dct:relation ?eenheid .
+      }
+    }
+    WHERE {
+      VALUES ?eenheidClassificatie {
+        ${ALLOWED_BESTUURSEENHEID_CLASSIFICATIONS.map(sparqlEscapeUri).join(' ')}
+      }
+    
+      ?eenheid a besluit:Bestuurseenheid ;
+        mu:uuid ?eenheidId ;
+        besluit:classificatie ?eenheidClassificatie .
+    
+      BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?eenheidId), "/LoketLB-LPDCGebruiker")) as ?graph)
+      BIND(${sparqlEscapeUri(conceptualService)} as ?concept)
+    
+      GRAPH ?graph {
+        FILTER NOT EXISTS {
+          ?concept lpdcExt:hasConceptDisplayConfiguration ?configUri .
+          ?configUri dct:relation ?eenheid .
+        }
+      }
+    
+      ${/*this is a bit of trickery to generate UUID and URI's since STRUUID doesn't work properly in Virtuoso: https://github.com/openlink/virtuoso-opensource/issues/515#issuecomment-456848368 */''}
+      BIND(SHA512(CONCAT(STR(?concept), STR(?eenheidId))) as ?configId) ${/* concept + eenheid should be unique per config object */''}
+      BIND(IRI(CONCAT('http://data.lblod.info/id/conceptual-display-configuration/', STR(?configId))) as ?configUri)
+    }
+  `;
+
+  await updateSudo(insertConfigsQuery);
 }


### PR DESCRIPTION
Depends on https://github.com/lblod/app-digitaal-loket/pull/412 and https://github.com/lblod/frontend-loket/pull/290

TODO:

- [x] Update the flags when creating instances (based on concepts)
- [x] Update the "instantiated" flag when removing instances (and it was the last instance for that concept)
- [x] Add config objects to all bestuurseenheden when a new concept is created
- [ ] ~~Do we need to do something for concept deletes since they shouldn't happen? Delete all configs for that specific concept?~~ Not needed. Soft deletes do happen, but those shouldn't influence these configs for now.