### PR TITLE
Fix the json:api response when creating forms

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,9 +79,11 @@ app.post('/public-services/', async function(req, res) {
 
       return res.status(201).json({
         data: {
-          "type": "public-service",
+          "type": "public-services",
           "id": uuid,
-          "uri": uri
+          "attributes": {
+            "uri": uri
+          }
         }
       });
     } catch (e) {
@@ -103,9 +105,11 @@ app.post('/public-services/', async function(req, res) {
 
       return res.status(201).json({
         data: {
-          "type": "public-service",
+          "type": "public-services",
           "id": uuid,
-          "uri": uri
+          "attributes": {
+            "uri": uri
+          }
         }
       });
     } catch (e) {


### PR DESCRIPTION
The type should be plural and the uri should be listed under attributes.

mu-cl-resources uses plural types so we do it here as well to make it consistent.

This isn't strictly needed. We reload the model through mu-cl-resources afterwards, but this is just more correct.