### PR TITLE
Add an "archived" status to concepts

### DIFF
--- a/lib/postProcessLdesConceptualService.js
+++ b/lib/postProcessLdesConceptualService.js
@@ -41,10 +41,19 @@ export async function processLdesDelta(delta) {
 
   for(const entry of toProcess) {
     try {
-      await updateNewLdesVersion(entry.graph.value, entry.subject.value, entry.object.value);
-      await updatedVersionInformation(entry.subject.value, entry.object.value);
-      await flagInstancesModifiedConcept(entry.graph.value, entry.subject.value, entry.object.value);
-      await ensureConceptDisplayConfigs(entry.graph.value, entry.subject.value, entry.object.value);
+      const versionedServiceGraph = entry.graph.value;
+      const versionedService = entry.subject.value;
+      const conceptualService = entry.object.value;
+      const isArchiving = await isArchivingEvent(versionedServiceGraph, versionedService);
+
+      await updateNewLdesVersion(versionedServiceGraph, versionedService, conceptualService);
+      await updatedVersionInformation(versionedService, conceptualService);
+      await flagInstancesModifiedConcept(conceptualService, isArchiving);
+      await ensureConceptDisplayConfigs(conceptualService);
+
+      if (isArchiving) {
+        await markConceptAsArchived(conceptualService);
+      }
     } catch (e) {
       console.error(`Error processing: ${JSON.stringify(entry)}`);
       console.error(e);
@@ -352,22 +361,10 @@ async function insertCodeListData(codeListData,
 }
 
 
-async function flagInstancesModifiedConcept(vGraph, vService, service) {
-  const isDeleteQuery = `
-    ASK {
-      GRAPH ${sparqlEscapeUri(vGraph)} {
-        ${sparqlEscapeUri(vService)}
-          <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#snapshotType>
-          <https://productencatalogus.data.vlaanderen.be/id/concept/SnapshotType/Delete>.
-      }
-    }
-  `;
-
-  const isDelete = (await querySudo(isDeleteQuery))?.boolean;
-
+async function flagInstancesModifiedConcept(service, isArchiving) {
   let status = 'http://lblod.data.gift/concepts/5a3168e2-f39b-4b5d-8638-29f935023c83'; //Update
-  if(isDelete) {
-    status = 'http://lblod.data.gift/concepts/cf22e8d1-23c3-45da-89bc-00826eaf23c3'; //Delete
+  if (isArchiving) {
+    status = 'http://lblod.data.gift/concepts/cf22e8d1-23c3-45da-89bc-00826eaf23c3'; // Archiving
   }
 
   const updateQueryStr  = `
@@ -394,7 +391,7 @@ async function flagInstancesModifiedConcept(vGraph, vService, service) {
   await updateSudo(updateQueryStr);
 }
 
-async function ensureConceptDisplayConfigs(versionedServiceGraph, versionedService, conceptualService) {
+async function ensureConceptDisplayConfigs(conceptualService) {
   // This list limits the type of bestuurseenheden for which the config objects will be created.
   // Only types that have access to the LPDC module should be added here.
   const ALLOWED_BESTUURSEENHEID_CLASSIFICATIONS = [
@@ -441,4 +438,35 @@ async function ensureConceptDisplayConfigs(versionedServiceGraph, versionedServi
   `;
 
   await updateSudo(insertConfigsQuery);
+}
+
+async function isArchivingEvent(versionedServiceGraph, versionedService) {
+  // IPDC sends archiving events as snapshot type "Delete" since they don't do hard deletes.
+  const isDeleteSnapshotTypeQuery = `
+    ASK {
+      GRAPH ${sparqlEscapeUri(versionedServiceGraph)} {
+        ${sparqlEscapeUri(versionedService)}
+          <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#snapshotType>
+          <https://productencatalogus.data.vlaanderen.be/id/concept/SnapshotType/Delete> .
+      }
+    }
+  `;
+
+  const isDeleteSnapshotType = (await querySudo(isDeleteSnapshotTypeQuery))?.boolean;
+  return isDeleteSnapshotType;
+}
+
+async function markConceptAsArchived(conceptualService) {
+  const archivedStatusConcept = 'http://lblod.data.gift/concepts/3f2666df-1dae-4cc2-a8dc-e8213e713081';
+  const markAsArchivedQuery = `
+    ${PREFIXES}
+
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(CONCEPTUAL_SERVICE_GRAPH)} {
+        ${sparqlEscapeUri(conceptualService)} adms:status ${sparqlEscapeUri(archivedStatusConcept)} .
+      }
+    }
+  `
+
+  await updateSudo(markAsArchivedQuery);
 }


### PR DESCRIPTION
When IPDC sends an archiving event over the LDES feed we now update the status of the concept to "archived". This allows us to hide the concept in the creation and link flows and makes it possible to show a message on the details page as well.

This still needs to be tested with the test LDES endpoint (https://github.com/lblod/app-ldes-endpoint)