### PR TITLE
Conditionally load schemes

### DIFF
--- a/lib/retrieveForm.js
+++ b/lib/retrieveForm.js
@@ -86,8 +86,15 @@ export async function retrieveForm(publicServiceId, formId) {
   `;
 
   const tailoredSchemes = await generateRuntimeConceptSchemes();
-  const storeSchemes = await querySudo(schemesQuery);
-  const meta = [ ...bindingsToNT(storeSchemes.results.bindings), ...tailoredSchemes ].join("\r\n");
+
+  let meta, storeSchemes;
+  if (schemes.length > 0) {
+    storeSchemes = await querySudo(schemesQuery);
+    meta = [ ...bindingsToNT(storeSchemes.results.bindings), ...tailoredSchemes ].join("\r\n");
+  } else {
+    meta = [ ...tailoredSchemes ].join("\r\n");
+  }
+
   const source = bindingsToNT(sourceBindings).join("\r\n");
 
   return { form, meta, source, serviceUri };


### PR DESCRIPTION
The current codebase tries the expensive `schemesQuery` regardless whether there are `schemes` loaded or not; this PR allows to conditionally execute the query depending on whether there are schemes or not.