### PR TITLE
Remove DELETE DATA workarounds

### DIFF
--- a/lib/createForm.js
+++ b/lib/createForm.js
@@ -118,8 +118,8 @@ export async function createForm(conceptId, bestuurseenheid) {
   allTriples = _.flattenDeep(allTriples);
   allTriples = bindingsToNT(allTriples);
 
-  // We need gradual insert, triple per triple, because contains LOOONG html
-  // This also implies we have to set the types first, since else we migth confuse mu-auth
+  // We do a gradual triple-by-triple gradual insert because it contains LOOONG html.
+  // This also implies we have to set the types first; otherwise, we might confuse mu-auth.
   const typeTriples = allTriples.filter(t => t.includes('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'));
   const otherTriples = allTriples.filter(t => !t.includes('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'));
 
@@ -134,7 +134,7 @@ export async function createForm(conceptId, bestuurseenheid) {
     await update(newPublicServiceQuery);
   }
 
-  //some extra meta data is needed
+  // Some extra meta data is needed
   const newServiceUri = Object.values(publicServiceData)[0][0].s.value;
   const newServiceUuid = Object.values(publicServiceData)[0]
         .find(triple => triple.p.value == 'http://mu.semte.ch/vocabularies/core/uuid').o.value;
@@ -173,7 +173,7 @@ export async function createForm(conceptId, bestuurseenheid) {
 }
 
 /*
- * Helper function to execute a query and copy retreived resources into new resources.
+ * Helper function to execute a query and copy retrieved resources into new resources.
  * It adds both a UUID and dct:source to the new resource too.
  * It returns an intermediate data structure. Which is easier to use when relations need
  * to be copied over.
@@ -223,7 +223,7 @@ function copySubject(oldUri, triplesData, uriTemplate) {
 
 /*
  * Replaces the children of a parent (i.e. relations) with new URI's
- * Probably this function won't be used outside this file.
+ * This function probably won't be used outside this file.
  * The input is the output of copySubjects.
  *
  * @param {Object}: {'http://old/parent/uri': [ {s: binding, p: binding, o:  { {value: 'http://old/child' } } } ] }
@@ -281,38 +281,20 @@ async function getSpatialForBestuurseenheid(bestuurseenheid) {
 }
 
 async function updateConceptDisplayConfig(conceptUri) {
-  // The fact the query is split up in pieces, is dueu to the
-  // virtuoso bug: https://github.com/openlink/virtuoso-opensource/issues/1055
-  // Once we have the latest version of virtuoso running, we can make it prettier.
-  // Note: this doesn't fix the custom boolean data type, this needs to be carefully considered.
   await update(`
     ${PREFIXES}
 
     DELETE {
       GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
-        ?config lpdcExt:conceptIsNew ?oldIsNew.
+        ?config lpdcExt:conceptIsNew ?oldIsNew ;
+          lpdcExt:conceptInstantiated ?oldIsInstantiated .
       }
     }
     WHERE {
       GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
         ${sparqlEscapeUri(conceptUri)} lpdcExt:hasConceptDisplayConfiguration ?config .
-        ?config lpdcExt:conceptIsNew ?oldIsNew.
-      }
-    }
-  `);
-
-  await update(`
-    ${PREFIXES}
-
-    DELETE {
-      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
-        ?config lpdcExt:conceptInstantiated ?oldIsInstantiated .
-      }
-    }
-    WHERE {
-      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
-        ${sparqlEscapeUri(conceptUri)} lpdcExt:hasConceptDisplayConfiguration ?config .
-        ?config lpdcExt:conceptInstantiated ?oldIsInstantiated .
+        ?config lpdcExt:conceptIsNew ?oldIsNew ;
+          lpdcExt:conceptInstantiated ?oldIsInstantiated .
       }
     }
   `);

--- a/lib/deleteForm.js
+++ b/lib/deleteForm.js
@@ -1,4 +1,4 @@
-import { sparqlEscapeString, sparqlEscapeUri, sparqlEscapeDateTime, update, query } from 'mu';
+import { sparqlEscapeUri, sparqlEscapeDateTime, update, query } from 'mu';
 import { APPLICATION_GRAPH, PREFIXES } from '../config';
 import { bindingsToNT } from '../utils/bindingsToNT';
 import { loadEvidences,
@@ -14,9 +14,6 @@ import { loadEvidences,
          loadAttachments,
          serviceUriForId
        } from './commonQueries';
-import { bestuurseenheidForSession, isAllowdForLPDC } from '../utils/session-utils';
-import { getScopedGraphsForStatement } from '../utils/common';
-import { updateSudo } from '@lblod/mu-auth-sudo';
 
 export async function deleteForm(serviceId, sessionUri) {
   const serviceUri = await serviceUriForId(serviceId);
@@ -45,34 +42,18 @@ export async function deleteForm(serviceId, sessionUri) {
   const sourceBindings = results
         .reduce((acc, b) => [...acc, ...b]);
 
-  // Start workaround bug virtuoso and lang strings.
-  // See updateForm.js for longer explanation.
-  // Keep code in sync with updateForm.js
   const source = bindingsToNT(sourceBindings);
 
-  if(!(await isAllowdForLPDC(sessionUri))) {
-      throw `Session ${sessionUri} is not an LPDC User`;
-  }
+  await update(`
+    DELETE DATA {
+      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+        ${source.join('\n')}
+      }
+    }`
+  );
 
-  const { uuid } = await bestuurseenheidForSession(sessionUri);
-  for(const statement of source ) {
-    // The workaround: ensure mu-auth deletes one triple in one graph at a time. We know that works.
-    const targetGraphPattern = `http://mu.semte.ch/graphs/organizations/${uuid}/`;
-    const targetGraphs = await getScopedGraphsForStatement(statement, targetGraphPattern);
-
-    for(const graph of targetGraphs) {
-      await updateSudo(`
-        DELETE DATA {
-          GRAPH ${sparqlEscapeUri(graph)} {
-            ${statement}
-          }
-        }`);
-    }
-  }
-  // End workaround bug virtuoso and lang strings.
-
-  // Since we want to keep track of the ones deleted and keep the LDES-feed
-  // consistent, we mark these as:Tombstone
+  // Since we want to keep track of the deleted services and keep the LDES-feed
+  // consistent, we mark these as "Tombstones".
   const now = new Date();
   const insertTombstoneQuery = `
     ${PREFIXES}

--- a/lib/postProcessLdesConceptualService.js
+++ b/lib/postProcessLdesConceptualService.js
@@ -137,16 +137,13 @@ async function removeConceptualService( serviceId ) {
 
   const source = bindingsToNT(sourceBindings);
 
-  // Due to confirmed bug in virtuoso, we need to execute statements
-  // separatly: https://github.com/openlink/virtuoso-opensource/issues/1055
-  for(const statement of source ) {
-      await updateSudo(`
-        DELETE DATA {
-          GRAPH ${sparqlEscapeUri(graph)} {
-            ${statement}
-          }
-        }`);
-  }
+  await update(`
+    DELETE DATA {
+      GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+        ${source.join('\n')}
+      }
+    }`
+  );
 }
 
 async function updateConceptualService( versionedServiceGraph, versionedServiceUri, serviceUri, serviceId ) {

--- a/lib/updateForm.js
+++ b/lib/updateForm.js
@@ -1,9 +1,6 @@
 import { uuid, update, sparqlEscapeUri } from 'mu';
-import { updateSudo } from '@lblod/mu-auth-sudo';
-import { APPLICATION_GRAPH, PREFIXES } from '../config';
+import { APPLICATION_GRAPH } from '../config';
 import { Graph, RDFNode, parse } from '../utils/rdflib';
-import { bestuurseenheidForSession, isAllowdForLPDC } from '../utils/session-utils';
-import { getScopedGraphsForStatement } from '../utils/common';
 
 export async function updateForm(data, sessionUri) {
   if(data.removals) await mutate('DELETE', data.removals, sessionUri);
@@ -17,53 +14,12 @@ async function mutate(mutationType, statements, sessionUri = null) {
   const parsedStatements = store.match(undefined, undefined, undefined, RDFNode(graph));
 
   if (parsedStatements.length > 0) {
-    if(mutationType == 'DELETE') {
-      // This is one hell of a workaround for a bug in virtuoso.
-      // the bug: https://github.com/openlink/virtuoso-opensource/issues/1055
-      // Due to this bug, deleting can't be delegated to mu-auth in the following case:
-      //  A session DELETING a triple with a langString, that has a type occuring
-      //  in multiple mu-allowed-groups AND the session having matching mu-allowed-groups
-      // (In short: when a langTyped triple needs to be removed from multiple graphs).
-      // Hence, we'll have to do some extra work ourselves.
-      // We first check if the session has LPDC-rights, because we end up in sudo-space
-      // If allowed, we make very specific calls, we know work for virtuoso through mu-auth. (see implemenetation)
-      // We do a best effort check, but it is NOT bullet proof.
-      // No type checking is done (what mu-auth should do), so all triples of the organisation the session is linked to, can be removed.
-      // That would be in case we have very smart (authenticated) users (their fault) OR
-      //   if a triple also IS availible in another graph, the session is not allowed on (sorry if you'll ever have to debug this).
-      // We expect these to be a mega-edge case, but warn here.
-      // There is new version of mu-auth underway, which will easily shield us from virtuoso. Or maybe the bugfix from virtuoso is earlier.
-      // Keep code in sync with deleteForm.js
-
-      if(!(await isAllowdForLPDC(sessionUri))) {
-          throw `Session ${sessionUri} is not an LPDC User`;
-      }
-
-      const { uuid } = await bestuurseenheidForSession(sessionUri);
-
-      const source = parsedStatements.map(t => t.toNT());
-      for(const statement of source ) {
-        // The workaround: ensure mu-auth deletes one triple in one graph at a time. We know that works.
-        const targetGraphPattern = `http://mu.semte.ch/graphs/organizations/${uuid}/`;
-        const targetGraphs = await getScopedGraphsForStatement(statement, targetGraphPattern);
-
-        for(const graph of targetGraphs) {
-          await updateSudo(`
-            DELETE DATA {
-              GRAPH ${sparqlEscapeUri(graph)} {
-                ${statement}
-              }
-            }`);
+    await update(`
+      ${mutationType} DATA {
+        GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
+          ${parsedStatements.join('\n')}
         }
-      }
-    }
-    else {
-      await update(`
-        ${mutationType} DATA {
-          GRAPH ${sparqlEscapeUri(APPLICATION_GRAPH)} {
-            ${parsedStatements.join('\n')}
-          }
-        }`);
-    }
+      }`
+    );
   }
 }


### PR DESCRIPTION
This PR removes the workarounds made due to the following bug (https://github.com/openlink/virtuoso-opensource/issues/1055) which is fixed in the latest Virtuoso release; the workaround mainly involved around performing `DELETE`s on a triple-by-triple basis, instead of bundling them all under one `DELETE` query.

The different flows have been tested with the exception of the one in https://github.com/lblod/lpdc-management-service/blob/development/lib/postProcessLdesConceptualService.js#L110 (specifically here: https://github.com/lblod/lpdc-management-service/blob/development/lib/postProcessLdesConceptualService.js#L140-L149).