### PR TITLE
Don't merge competent authorities from concept

### DIFF
--- a/src/core/domain/bring-instance-up-to-date-with-concept-snapshot-version-domain-service.ts
+++ b/src/core/domain/bring-instance-up-to-date-with-concept-snapshot-version-domain-service.ts
@@ -59,7 +59,8 @@ export class BringInstanceUpToDateWithConceptSnapshotVersionDomainService {
             .withTargetAudiences(conceptSnapshotInInstanceLanguage.targetAudiences)
             .withThemes(conceptSnapshotInInstanceLanguage.themes)
             .withCompetentAuthorityLevels(conceptSnapshotInInstanceLanguage.competentAuthorityLevels)
-            .withCompetentAuthorities(conceptSnapshotInInstanceLanguage.competentAuthorities)
+            // Do not blindly merge Competent Authorities. Field from concept can be empty, making the required form field invalid.
+            //.withCompetentAuthorities(conceptSnapshotInInstanceLanguage.competentAuthorities)
             .withExecutingAuthorityLevels(conceptSnapshotInInstanceLanguage.executingAuthorityLevels)
             .withPublicationMedia(conceptSnapshotInInstanceLanguage.publicationMedia)
             .withYourEuropeCategories(conceptSnapshotInInstanceLanguage.yourEuropeCategories)

--- a/src/core/domain/bring-instance-up-to-date-with-concept-snapshot-version-domain-service.ts
+++ b/src/core/domain/bring-instance-up-to-date-with-concept-snapshot-version-domain-service.ts
@@ -9,7 +9,7 @@ import {FormatPreservingDate} from "./format-preserving-date";
 import {InvariantError} from "./shared/lpdc-error";
 import {SelectConceptLanguageDomainService} from "./select-concept-language-domain-service";
 import {Language} from "./language";
-import {InstanceReviewStatusType, InstanceStatusType} from "./types";
+import {InstanceReviewStatusType, InstanceStatusType, CompetentAuthorityLevelType} from "./types";
 
 export class BringInstanceUpToDateWithConceptSnapshotVersionDomainService {
 
@@ -47,7 +47,10 @@ export class BringInstanceUpToDateWithConceptSnapshotVersionDomainService {
         const conceptSnapshotInInstanceLanguage = conceptSnapshot
             .transformLanguage(conceptSnapshotLanguage, instanceLanguage);
 
-        const instanceMergedWithConceptSnapshot = InstanceBuilder.from(instanceInStatusOntwerp)
+        const hasCompetentAuthorityLevelLokaal = instanceInStatusOntwerp.competentAuthorityLevels.includes(CompetentAuthorityLevelType.LOKAAL);
+        const newCompetentAuthorityFilledIn = conceptSnapshotInInstanceLanguage.competentAuthorities.length > 0;
+
+        const instanceMergedWithConceptSnapshotBuilder = InstanceBuilder.from(instanceInStatusOntwerp)
             .withTitle(conceptSnapshotInInstanceLanguage.title)
             .withDescription(conceptSnapshotInInstanceLanguage.description)
             .withAdditionalDescription(conceptSnapshotInInstanceLanguage.additionalDescription)
@@ -59,8 +62,6 @@ export class BringInstanceUpToDateWithConceptSnapshotVersionDomainService {
             .withTargetAudiences(conceptSnapshotInInstanceLanguage.targetAudiences)
             .withThemes(conceptSnapshotInInstanceLanguage.themes)
             .withCompetentAuthorityLevels(conceptSnapshotInInstanceLanguage.competentAuthorityLevels)
-            // Do not blindly merge Competent Authorities. Field from concept can be empty, making the required form field invalid.
-            //.withCompetentAuthorities(conceptSnapshotInInstanceLanguage.competentAuthorities)
             .withExecutingAuthorityLevels(conceptSnapshotInInstanceLanguage.executingAuthorityLevels)
             .withPublicationMedia(conceptSnapshotInInstanceLanguage.publicationMedia)
             .withYourEuropeCategories(conceptSnapshotInInstanceLanguage.yourEuropeCategories)
@@ -70,11 +71,15 @@ export class BringInstanceUpToDateWithConceptSnapshotVersionDomainService {
             .withCosts(conceptSnapshotInInstanceLanguage.costs.map(co => co.transformWithNewId()))
             .withFinancialAdvantages(conceptSnapshotInInstanceLanguage.financialAdvantages.map(fa => fa.transformWithNewId()))
             .withLegalResources(conceptSnapshotInInstanceLanguage.legalResources.map(lr => lr.transformWithNewId()))
-            .withProductId(conceptSnapshotInInstanceLanguage.productId)
-            .build();
+            .withProductId(conceptSnapshotInInstanceLanguage.productId);
+
+        if (!hasCompetentAuthorityLevelLokaal && newCompetentAuthorityFilledIn) {
+            instanceMergedWithConceptSnapshotBuilder.withCompetentAuthorities(conceptSnapshotInInstanceLanguage.competentAuthorities);
+        }
+
+        const instanceMergedWithConceptSnapshot = instanceMergedWithConceptSnapshotBuilder.build();
 
         await this.confirmUpToDateTill(bestuurseenheid, instanceMergedWithConceptSnapshot, instanceVersion, conceptSnapshot);
-
     }
 
     async confirmUpToDateTill(bestuurseenheid: Bestuurseenheid, instance: Instance, instanceVersion: FormatPreservingDate, conceptSnapshot: ConceptSnapshot): Promise<void> {


### PR DESCRIPTION
**[LPDC-1255]**

The field from the concept is empty when the concept is meant for local authorities. This causes the form field to be empty after a merge, which is invalid and the instance cannot be sent without manual intervention.

**How to test correct workings**

Use a build with these changes in the stack (https://github.com/lblod/app-lpdc-digitaal-loket/tree/development). Observe an instance that has a new concept version. Make sure the instance is complete/valid (all required fields filled in). Use the "Wijzigingen overnemen" functionality, and "Concept volledig overnemen". Check afterwards that the "Bevoegde overheid" (and other required fields) are still filled in and that the instance can be sent in.