### PR TITLE
chore: use updated version of NUTS code list

### DIFF
--- a/src/driven/persistence/bestuurseenheid-sparql-repository.ts
+++ b/src/driven/persistence/bestuurseenheid-sparql-repository.ts
@@ -1,22 +1,26 @@
-import {BestuurseenheidRepository} from "../../core/port/driven/persistence/bestuurseenheid-repository";
-import {Iri} from "../../core/domain/shared/iri";
-import {Bestuurseenheid, BestuurseenheidClassificatieCode,} from "../../core/domain/bestuurseenheid";
-import {sparqlEscapeUri} from "../../../mu-helper";
-import {SparqlQuerying} from "./sparql-querying";
-import {PREFIX, PUBLIC_GRAPH} from "../../../config";
-import {extractResultsFromAllSettled} from "../../../platform/promises";
-import {NotFoundError} from "../../core/domain/shared/lpdc-error";
+import { BestuurseenheidRepository } from "../../core/port/driven/persistence/bestuurseenheid-repository";
+import { Iri } from "../../core/domain/shared/iri";
+import {
+  Bestuurseenheid,
+  BestuurseenheidClassificatieCode,
+} from "../../core/domain/bestuurseenheid";
+import { sparqlEscapeUri } from "../../../mu-helper";
+import { SparqlQuerying } from "./sparql-querying";
+import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { extractResultsFromAllSettled } from "../../../platform/promises";
+import { NotFoundError } from "../../core/domain/shared/lpdc-error";
 
-export class BestuurseenheidSparqlRepository implements BestuurseenheidRepository {
+export class BestuurseenheidSparqlRepository
+  implements BestuurseenheidRepository
+{
+  protected readonly querying: SparqlQuerying;
 
-    protected readonly querying: SparqlQuerying;
+  constructor(endpoint?: string) {
+    this.querying = new SparqlQuerying(endpoint);
+  }
 
-    constructor(endpoint?: string) {
-        this.querying = new SparqlQuerying(endpoint);
-    }
-
-    async findById(id: Iri): Promise<Bestuurseenheid> {
-        const bestuurseenheidQuery = `
+  async findById(id: Iri): Promise<Bestuurseenheid> {
+    const bestuurseenheidQuery = `
             ${PREFIX.skos}
             ${PREFIX.besluit}
             ${PREFIX.mu}
@@ -34,7 +38,7 @@ export class BestuurseenheidSparqlRepository implements BestuurseenheidRepositor
                 }
             }
         `;
-        const spatialsQuery = `
+    const spatialsQuery = `
             ${PREFIX.besluit}
             ${PREFIX.skos}
             ${PREFIX.nutss}
@@ -42,68 +46,78 @@ export class BestuurseenheidSparqlRepository implements BestuurseenheidRepositor
                 GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {
                   ${sparqlEscapeUri(id)} besluit:werkingsgebied ?werkingsgebiedId.
                   ?werkingsgebiedId skos:exactMatch ?spatialId.
-                  ?spatialId skos:inScheme nutss:2021
+                  ?spatialId skos:inScheme nutss:2024
                 }
             }        
         `;
 
-        const [
-            bestuurseenheidQueryResult,
-            resultSpatials] =
-            await extractResultsFromAllSettled(
-                [
-                    this.querying.singleRow(bestuurseenheidQuery),
-                    this.querying.list(spatialsQuery)]);
+    const [bestuurseenheidQueryResult, resultSpatials] =
+      await extractResultsFromAllSettled([
+        this.querying.singleRow(bestuurseenheidQuery),
+        this.querying.list(spatialsQuery),
+      ]);
 
-        if (!bestuurseenheidQueryResult) {
-            throw new NotFoundError(`Geen bestuurseenheid gevonden voor iri: ${id}`);
-        }
-
-        return new Bestuurseenheid(
-            new Iri(bestuurseenheidQueryResult['id'].value),
-            bestuurseenheidQueryResult['uuid'].value,
-            bestuurseenheidQueryResult['prefLabel'].value,
-            this.mapBestuurseenheidClassificatieUriToCode(bestuurseenheidQueryResult['classificatieUri']?.value),
-            (resultSpatials as Promise<unknown>[]).map(r => new Iri(r['spatialId'].value))
-        );
+    if (!bestuurseenheidQueryResult) {
+      throw new NotFoundError(`Geen bestuurseenheid gevonden voor iri: ${id}`);
     }
 
-    mapBestuurseenheidClassificatieUriToCode(classificatieCodeUri: BestuurseenheidClassificatieCodeUri | undefined): BestuurseenheidClassificatieCode | undefined {
-        if (!classificatieCodeUri) {
-            return undefined;
-        }
+    return new Bestuurseenheid(
+      new Iri(bestuurseenheidQueryResult["id"].value),
+      bestuurseenheidQueryResult["uuid"].value,
+      bestuurseenheidQueryResult["prefLabel"].value,
+      this.mapBestuurseenheidClassificatieUriToCode(
+        bestuurseenheidQueryResult["classificatieUri"]?.value,
+      ),
+      (resultSpatials as Promise<unknown>[]).map(
+        (r) => new Iri(r["spatialId"].value),
+      ),
+    );
+  }
 
-        const key: string | undefined = Object.keys(BestuurseenheidClassificatieCodeUri)
-            .find(key => BestuurseenheidClassificatieCodeUri[key] === classificatieCodeUri);
-
-        const classificatieCode = BestuurseenheidClassificatieCode[key];
-
-        if (!classificatieCode) {
-            throw new NotFoundError(`Geen classificatiecode gevonden voor: ${classificatieCodeUri}`);
-        }
-        return classificatieCode;
+  mapBestuurseenheidClassificatieUriToCode(
+    classificatieCodeUri: BestuurseenheidClassificatieCodeUri | undefined,
+  ): BestuurseenheidClassificatieCode | undefined {
+    if (!classificatieCodeUri) {
+      return undefined;
     }
+
+    const key: string | undefined = Object.keys(
+      BestuurseenheidClassificatieCodeUri,
+    ).find(
+      (key) =>
+        BestuurseenheidClassificatieCodeUri[key] === classificatieCodeUri,
+    );
+
+    const classificatieCode = BestuurseenheidClassificatieCode[key];
+
+    if (!classificatieCode) {
+      throw new NotFoundError(
+        `Geen classificatiecode gevonden voor: ${classificatieCodeUri}`,
+      );
+    }
+    return classificatieCode;
+  }
 }
 
 export enum BestuurseenheidClassificatieCodeUri {
-    PROVINCIE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000",
-    GEMEENTE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001",
-    OCMW = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002",
-    DISTRICT = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003",
-    INTERCOMMUNALE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000004",
-    INTERLOKAAL_SAMENWERKINGSVERBAND_ZONDER_RECHTSPERSOONLIJKHEID = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/0657f97f-3ad2-4f72-a61c-abb10c206249",
-    INTERGEMEENTELIJK_SAMENWERKINGSVERBAND_ZONDER_RECHTSPERSOONLIJKHEID = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a30f5e3f-7e6a-4352-a9da-57ea46a5e98d",
-    AUTONOOM_GEMEENTEBEDRIJF = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721",
-    AUTONOOM_PROVINCIEBEDRIJF = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d",
-    DIENSTVERLENENDE_VERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71",
-    HULPVERLENINGSZONE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562",
-    OPDRACHTHOUDENDE_VERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d",
-    OPDRACHTHOUDENDE_VERENIGING_MET_PRIVATE_DEELNAME = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d46b2acb-4763-4532-9aff-fdede39e9520",
-    WATERING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/293e5f58-9544-496e-88e0-734a137f6ebc",
-    POLDERS = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d312c541-a263-4004-bca2-63eb991458c3",
-    POLITIEZONE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc",
-    PROJECTVERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/b156b67f-c5f4-4584-9b30-4c090be02fdc",
-    WELZIJNSVERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9",
-    OCMW_VERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089",
-    VLAAMSE_GEMEENSCHAPSCOMMISSIE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c",
+  PROVINCIE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000",
+  GEMEENTE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001",
+  OCMW = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002",
+  DISTRICT = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003",
+  INTERCOMMUNALE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000004",
+  INTERLOKAAL_SAMENWERKINGSVERBAND_ZONDER_RECHTSPERSOONLIJKHEID = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/0657f97f-3ad2-4f72-a61c-abb10c206249",
+  INTERGEMEENTELIJK_SAMENWERKINGSVERBAND_ZONDER_RECHTSPERSOONLIJKHEID = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a30f5e3f-7e6a-4352-a9da-57ea46a5e98d",
+  AUTONOOM_GEMEENTEBEDRIJF = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721",
+  AUTONOOM_PROVINCIEBEDRIJF = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d",
+  DIENSTVERLENENDE_VERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71",
+  HULPVERLENINGSZONE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562",
+  OPDRACHTHOUDENDE_VERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d",
+  OPDRACHTHOUDENDE_VERENIGING_MET_PRIVATE_DEELNAME = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d46b2acb-4763-4532-9aff-fdede39e9520",
+  WATERING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/293e5f58-9544-496e-88e0-734a137f6ebc",
+  POLDERS = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d312c541-a263-4004-bca2-63eb991458c3",
+  POLITIEZONE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc",
+  PROJECTVERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/b156b67f-c5f4-4584-9b30-4c090be02fdc",
+  WELZIJNSVERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9",
+  OCMW_VERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089",
+  VLAAMSE_GEMEENSCHAPSCOMMISSIE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c",
 }

--- a/src/driven/persistence/forms/eigenschappen/form.ttl
+++ b/src/driven/persistence/forms/eigenschappen/form.ttl
@@ -225,7 +225,7 @@ ext:authorityPg a form:PropertyGroup;
       sh:path dct:spatial ;
       form:options  """
                      {
-                       "conceptScheme":"http://data.europa.eu/nuts/scheme/2021",
+                       "conceptScheme":"http://data.europa.eu/nuts/scheme/2024",
                        "multiple": true
                      }
                     """ ;

--- a/test/driven/persistence/bestuurseenheid-repository.it-test.ts
+++ b/test/driven/persistence/bestuurseenheid-repository.it-test.ts
@@ -1,220 +1,254 @@
-import {TEST_SPARQL_ENDPOINT} from "../../test.config";
-import {BestuurseenheidClassificatieCodeUri} from "../../../src/driven/persistence/bestuurseenheid-sparql-repository";
-import {Bestuurseenheid, BestuurseenheidClassificatieCode} from "../../../src/core/domain/bestuurseenheid";
-import {aBestuurseenheid} from "../../core/domain/bestuurseenheid-test-builder";
-import {BestuurseenheidSparqlTestRepository} from "./bestuurseenheid-sparql-test-repository";
-import {DirectDatabaseAccess} from "./direct-database-access";
-import {uuid} from "../../../mu-helper";
+import { TEST_SPARQL_ENDPOINT } from "../../test.config";
+import { BestuurseenheidClassificatieCodeUri } from "../../../src/driven/persistence/bestuurseenheid-sparql-repository";
 import {
-    buildBestuurseenheidIri,
-    buildNutsCodeIri,
-    buildWerkingsgebiedenIri,
-    randomNumber
+  Bestuurseenheid,
+  BestuurseenheidClassificatieCode,
+} from "../../../src/core/domain/bestuurseenheid";
+import { aBestuurseenheid } from "../../core/domain/bestuurseenheid-test-builder";
+import { BestuurseenheidSparqlTestRepository } from "./bestuurseenheid-sparql-test-repository";
+import { DirectDatabaseAccess } from "./direct-database-access";
+import { uuid } from "../../../mu-helper";
+import {
+  buildBestuurseenheidIri,
+  buildNutsCodeIri,
+  buildWerkingsgebiedenIri,
+  randomNumber,
 } from "../../core/domain/iri-test-builder";
-import {Iri} from "../../../src/core/domain/shared/iri";
-import {PUBLIC_GRAPH} from "../../../config";
-import {NotFoundError} from "../../../src/core/domain/shared/lpdc-error";
+import { Iri } from "../../../src/core/domain/shared/iri";
+import { PUBLIC_GRAPH } from "../../../config";
+import { NotFoundError } from "../../../src/core/domain/shared/lpdc-error";
 
-describe('BestuurseenheidRepository', () => {
-    const repository = new BestuurseenheidSparqlTestRepository(TEST_SPARQL_ENDPOINT);
-    const directDatabaseAccess = new DirectDatabaseAccess(TEST_SPARQL_ENDPOINT);
+describe("BestuurseenheidRepository", () => {
+  const repository = new BestuurseenheidSparqlTestRepository(
+    TEST_SPARQL_ENDPOINT,
+  );
+  const directDatabaseAccess = new DirectDatabaseAccess(TEST_SPARQL_ENDPOINT);
 
-    describe('findById', () => {
+  describe("findById", () => {
+    test("When bestuurseenheid exists with id, then return bestuurseenheid", async () => {
+      const bestuurseenheid = aBestuurseenheid().build();
+      await repository.save(bestuurseenheid);
 
-        test('When bestuurseenheid exists with id, then return bestuurseenheid', async () => {
-            const bestuurseenheid = aBestuurseenheid().build();
-            await repository.save(bestuurseenheid);
+      const anotherBestuurseenheid = aBestuurseenheid().build();
+      await repository.save(anotherBestuurseenheid);
 
-            const anotherBestuurseenheid = aBestuurseenheid().build();
-            await repository.save(anotherBestuurseenheid);
+      const actualBestuurseenheid = await repository.findById(
+        bestuurseenheid.id,
+      );
 
-            const actualBestuurseenheid = await repository.findById(bestuurseenheid.id);
-
-            expect(actualBestuurseenheid).toEqual(bestuurseenheid);
-        });
-
-        test('When bestuurseenheid does not exist with id, then throw error', async () => {
-            const bestuurseenheid = aBestuurseenheid().build();
-            await repository.save(bestuurseenheid);
-
-            const nonExistentBestuurseenheidId = buildBestuurseenheidIri("thisiddoesnotexist");
-
-            await expect(repository.findById(nonExistentBestuurseenheidId)).rejects.toThrowWithMessage(NotFoundError, `Geen bestuurseenheid gevonden voor iri: ${nonExistentBestuurseenheidId}`);
-
-        });
-
-        test('When bestuurseenheid abb exists with id, then return bestuurseenheid', async () => {
-            const bestuurseenheid =
-                aBestuurseenheid()
-                    .withId(Bestuurseenheid.abb)
-                    .withUuid("141d9d6b-54af-4d17-b313-8d1c30bc3f5b")
-                    .withPrefLabel('Agentschap binnenlands bestuur')
-                    .withClassificatieCode(undefined)
-                    .build();
-            await repository.save(bestuurseenheid);
-
-            const actualBestuurseenheid = await repository.findById(bestuurseenheid.id);
-
-            expect(actualBestuurseenheid.id).toEqual(Bestuurseenheid.abb);
-            expect(actualBestuurseenheid.prefLabel).toEqual('Agentschap binnenlands bestuur');
-            expect(actualBestuurseenheid.classificatieCode).toBeUndefined();
-        });
+      expect(actualBestuurseenheid).toEqual(bestuurseenheid);
     });
 
-    describe('Verify ontology and mapping', () => {
+    test("When bestuurseenheid does not exist with id, then throw error", async () => {
+      const bestuurseenheid = aBestuurseenheid().build();
+      await repository.save(bestuurseenheid);
 
-        test('Verify mappings', async () => {
-            const bestuurseenheidUuid = uuid();
-            const bestuurseenheidId = new Iri(`http://data.lblod.info/id/bestuurseenheden/${bestuurseenheidUuid}`);
+      const nonExistentBestuurseenheidId =
+        buildBestuurseenheidIri("thisiddoesnotexist");
 
-            const werkingsgebied1Id = buildWerkingsgebiedenIri(uuid());
-            const werkingsgebied2Id = buildWerkingsgebiedenIri(uuid());
-
-            const spatial1Id = buildNutsCodeIri(randomNumber(10000, 19999));
-            const spatial2Id = buildNutsCodeIri(randomNumber(20000, 29999));
-            const spatial3Id = buildNutsCodeIri(randomNumber(30000, 39999));
-            const spatial4Id = buildNutsCodeIri(randomNumber(40000, 49999));
-
-            const bestuurseenheid =
-                aBestuurseenheid()
-                    .withId(bestuurseenheidId)
-                    .withUuid(bestuurseenheidUuid)
-                    .withPrefLabel("preferred label")
-                    .withClassificatieCode(BestuurseenheidClassificatieCode.GEMEENTE)
-                    .withSpatials([
-                        spatial1Id,
-                        spatial2Id,
-                        spatial3Id,
-                        spatial4Id,
-                    ])
-                    .build();
-
-            await directDatabaseAccess.insertData(
-                PUBLIC_GRAPH,
-                [`<${bestuurseenheidId}> a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>`,
-                    `<${bestuurseenheidId}> <http://mu.semte.ch/vocabularies/core/uuid> """${bestuurseenheidUuid}"""`,
-                    `<${bestuurseenheidId}> <http://www.w3.org/2004/02/skos/core#prefLabel> """preferred label"""`,
-                    `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>`,
-                    `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <${werkingsgebied1Id}>`,
-                    `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <${werkingsgebied2Id}>`,
-                    `<${werkingsgebied1Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial1Id}>`,
-                    `<${werkingsgebied1Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial2Id}>`,
-                    `<${werkingsgebied2Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial3Id}>`,
-                    `<${werkingsgebied2Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial4Id}>`,
-                    `<${spatial1Id}> <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.europa.eu/nuts/scheme/2021>`,
-                    `<${spatial2Id}> <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.europa.eu/nuts/scheme/2021>`,
-                    `<${spatial3Id}> <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.europa.eu/nuts/scheme/2021>`,
-                    `<${spatial4Id}> <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.europa.eu/nuts/scheme/2021>`,
-                ]);
-
-            const actualBestuurseenheid = await repository.findById(bestuurseenheidId);
-
-            expect(actualBestuurseenheid).toEqual(bestuurseenheid);
-        });
-
-        test('Only query correct type', async () => {
-            const bestuurseenheidId = new Iri(`http://data.lblod.info/id/bestuurseenheden/${uuid()}`);
-
-            await directDatabaseAccess.insertData(
-                PUBLIC_GRAPH,
-                [`<${bestuurseenheidId}> a <http://example.com/ns#SomeOtherType>`,
-                    `<${bestuurseenheidId}> <http://www.w3.org/2004/02/skos/core#prefLabel> """preferred label"""`,
-                    `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>`,
-                ]);
-
-            await expect(repository.findById(bestuurseenheidId)).rejects.toThrowWithMessage(NotFoundError, `Geen bestuurseenheid gevonden voor iri: ${bestuurseenheidId}`);
-
-        });
-
-        test('a bestuurseenheid not linked to a werkingsgebied is returned', async () => {
-            const bestuurseenheidUuid = uuid();
-            const bestuurseenheidId = new Iri(`http://data.lblod.info/id/bestuurseenheden/${bestuurseenheidUuid}`);
-
-            await directDatabaseAccess.insertData(
-                PUBLIC_GRAPH,
-                [`<${bestuurseenheidId}> a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>`,
-                    `<${bestuurseenheidId}> <http://mu.semte.ch/vocabularies/core/uuid> """${bestuurseenheidUuid}"""`,
-                    `<${bestuurseenheidId}> <http://www.w3.org/2004/02/skos/core#prefLabel> """preferred label"""`,
-                    `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>`,
-                ]);
-
-            const actualBestuurseenheid = await repository.findById(bestuurseenheidId);
-
-            expect(actualBestuurseenheid.id).toEqual(bestuurseenheidId);
-        });
-
-        test('a spatial not linked to a nuts code is not returned', async () => {
-            const bestuurseenheidUuid = uuid();
-            const bestuurseenheidId = new Iri(`http://data.lblod.info/id/bestuurseenheden/${bestuurseenheidUuid}`);
-
-            const werkingsgebied1Id = buildWerkingsgebiedenIri(uuid());
-
-            const spatial1Id = buildNutsCodeIri(randomNumber(10000, 19999));
-
-            await directDatabaseAccess.insertData(
-                PUBLIC_GRAPH,
-                [`<${bestuurseenheidId}> a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>`,
-                    `<${bestuurseenheidId}> <http://mu.semte.ch/vocabularies/core/uuid> """${bestuurseenheidUuid}"""`,
-                    `<${bestuurseenheidId}> <http://www.w3.org/2004/02/skos/core#prefLabel> """preferred label"""`,
-                    `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>`,
-                    `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <${werkingsgebied1Id}>`,
-                    `<${werkingsgebied1Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial1Id}>`,
-                ]);
-
-            const actualBestuurseenheid = await repository.findById(bestuurseenheidId);
-
-            expect(actualBestuurseenheid.spatials).toEqual([]);
-        });
-
+      await expect(
+        repository.findById(nonExistentBestuurseenheidId),
+      ).rejects.toThrowWithMessage(
+        NotFoundError,
+        `Geen bestuurseenheid gevonden voor iri: ${nonExistentBestuurseenheidId}`,
+      );
     });
 
-    describe('map bestuurseenheidClassificatieCode to uri', () => {
+    test("When bestuurseenheid abb exists with id, then return bestuurseenheid", async () => {
+      const bestuurseenheid = aBestuurseenheid()
+        .withId(Bestuurseenheid.abb)
+        .withUuid("141d9d6b-54af-4d17-b313-8d1c30bc3f5b")
+        .withPrefLabel("Agentschap binnenlands bestuur")
+        .withClassificatieCode(undefined)
+        .build();
+      await repository.save(bestuurseenheid);
 
-        test('Check that all bestuurseenheid classification codes can get mapped. ', () => {
+      const actualBestuurseenheid = await repository.findById(
+        bestuurseenheid.id,
+      );
 
-            const classificatieCodes = Object.keys(BestuurseenheidClassificatieCode);
+      expect(actualBestuurseenheid.id).toEqual(Bestuurseenheid.abb);
+      expect(actualBestuurseenheid.prefLabel).toEqual(
+        "Agentschap binnenlands bestuur",
+      );
+      expect(actualBestuurseenheid.classificatieCode).toBeUndefined();
+    });
+  });
 
-            classificatieCodes.forEach(code => {
-                expect(repository.mapBestuurseenheidClassificatieCodeToUri(BestuurseenheidClassificatieCode[code])).toEqual(BestuurseenheidClassificatieCodeUri[code]);
-            });
+  describe("Verify ontology and mapping", () => {
+    test("Verify mappings", async () => {
+      const bestuurseenheidUuid = uuid();
+      const bestuurseenheidId = new Iri(
+        `http://data.lblod.info/id/bestuurseenheden/${bestuurseenheidUuid}`,
+      );
 
-        });
+      const werkingsgebied1Id = buildWerkingsgebiedenIri(uuid());
+      const werkingsgebied2Id = buildWerkingsgebiedenIri(uuid());
 
-        test('Non matched bestuurseenheid classification code throws error. ', () => {
-            const nonExistingClassificationCode = 'non-existing' as BestuurseenheidClassificatieCode;
-            expect(() => repository.mapBestuurseenheidClassificatieCodeToUri(nonExistingClassificationCode)).toThrowWithMessage(NotFoundError, `No classification code uri found for: ${nonExistingClassificationCode}`);
+      const spatial1Id = buildNutsCodeIri(randomNumber(10000, 19999));
+      const spatial2Id = buildNutsCodeIri(randomNumber(20000, 29999));
+      const spatial3Id = buildNutsCodeIri(randomNumber(30000, 39999));
+      const spatial4Id = buildNutsCodeIri(randomNumber(40000, 49999));
 
-        });
+      const bestuurseenheid = aBestuurseenheid()
+        .withId(bestuurseenheidId)
+        .withUuid(bestuurseenheidUuid)
+        .withPrefLabel("preferred label")
+        .withClassificatieCode(BestuurseenheidClassificatieCode.GEMEENTE)
+        .withSpatials([spatial1Id, spatial2Id, spatial3Id, spatial4Id])
+        .build();
 
+      await directDatabaseAccess.insertData(PUBLIC_GRAPH, [
+        `<${bestuurseenheidId}> a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>`,
+        `<${bestuurseenheidId}> <http://mu.semte.ch/vocabularies/core/uuid> """${bestuurseenheidUuid}"""`,
+        `<${bestuurseenheidId}> <http://www.w3.org/2004/02/skos/core#prefLabel> """preferred label"""`,
+        `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>`,
+        `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <${werkingsgebied1Id}>`,
+        `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <${werkingsgebied2Id}>`,
+        `<${werkingsgebied1Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial1Id}>`,
+        `<${werkingsgebied1Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial2Id}>`,
+        `<${werkingsgebied2Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial3Id}>`,
+        `<${werkingsgebied2Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial4Id}>`,
+        `<${spatial1Id}> <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.europa.eu/nuts/scheme/2024>`,
+        `<${spatial2Id}> <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.europa.eu/nuts/scheme/2024>`,
+        `<${spatial3Id}> <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.europa.eu/nuts/scheme/2024>`,
+        `<${spatial4Id}> <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.europa.eu/nuts/scheme/2024>`,
+      ]);
 
-        test('Enum of BestuurseenheidClassificatieCode and BestuurseenheidClassificatieCode should contain the same amount of elements   ', () => {
+      const actualBestuurseenheid =
+        await repository.findById(bestuurseenheidId);
 
-            const classificatieCodeCount = Object.keys(BestuurseenheidClassificatieCode).length;
-            const classificatieCodeUrisCount = Object.keys(BestuurseenheidClassificatieCodeUri).length;
-
-            expect(classificatieCodeCount).toBe(classificatieCodeUrisCount);
-        });
-
-
+      expect(actualBestuurseenheid).toEqual(bestuurseenheid);
     });
 
-    describe('map bestuurseenheidClassificatieUri to code', () => {
+    test("Only query correct type", async () => {
+      const bestuurseenheidId = new Iri(
+        `http://data.lblod.info/id/bestuurseenheden/${uuid()}`,
+      );
 
-        test('Check that all bestuurseenheid classification uris can get mapped. ', () => {
+      await directDatabaseAccess.insertData(PUBLIC_GRAPH, [
+        `<${bestuurseenheidId}> a <http://example.com/ns#SomeOtherType>`,
+        `<${bestuurseenheidId}> <http://www.w3.org/2004/02/skos/core#prefLabel> """preferred label"""`,
+        `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>`,
+      ]);
 
-            const classificatieCodesUri = Object.keys(BestuurseenheidClassificatieCodeUri);
-
-            classificatieCodesUri.forEach(code => {
-                expect(repository.mapBestuurseenheidClassificatieUriToCode(BestuurseenheidClassificatieCodeUri[code])).toEqual(BestuurseenheidClassificatieCode[code]);
-            });
-
-        });
-
-        test('Non matched bestuurseenheid classification uri throws error. ', () => {
-            const nonExistingClassificationUri = 'non-existing' as BestuurseenheidClassificatieCodeUri;
-            expect(() => repository.mapBestuurseenheidClassificatieUriToCode(nonExistingClassificationUri)).toThrowWithMessage(NotFoundError, `Geen classificatiecode gevonden voor: ${nonExistingClassificationUri}`);
-
-        });
-
+      await expect(
+        repository.findById(bestuurseenheidId),
+      ).rejects.toThrowWithMessage(
+        NotFoundError,
+        `Geen bestuurseenheid gevonden voor iri: ${bestuurseenheidId}`,
+      );
     });
+
+    test("a bestuurseenheid not linked to a werkingsgebied is returned", async () => {
+      const bestuurseenheidUuid = uuid();
+      const bestuurseenheidId = new Iri(
+        `http://data.lblod.info/id/bestuurseenheden/${bestuurseenheidUuid}`,
+      );
+
+      await directDatabaseAccess.insertData(PUBLIC_GRAPH, [
+        `<${bestuurseenheidId}> a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>`,
+        `<${bestuurseenheidId}> <http://mu.semte.ch/vocabularies/core/uuid> """${bestuurseenheidUuid}"""`,
+        `<${bestuurseenheidId}> <http://www.w3.org/2004/02/skos/core#prefLabel> """preferred label"""`,
+        `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>`,
+      ]);
+
+      const actualBestuurseenheid =
+        await repository.findById(bestuurseenheidId);
+
+      expect(actualBestuurseenheid.id).toEqual(bestuurseenheidId);
+    });
+
+    test("a spatial not linked to a nuts code is not returned", async () => {
+      const bestuurseenheidUuid = uuid();
+      const bestuurseenheidId = new Iri(
+        `http://data.lblod.info/id/bestuurseenheden/${bestuurseenheidUuid}`,
+      );
+
+      const werkingsgebied1Id = buildWerkingsgebiedenIri(uuid());
+
+      const spatial1Id = buildNutsCodeIri(randomNumber(10000, 19999));
+
+      await directDatabaseAccess.insertData(PUBLIC_GRAPH, [
+        `<${bestuurseenheidId}> a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>`,
+        `<${bestuurseenheidId}> <http://mu.semte.ch/vocabularies/core/uuid> """${bestuurseenheidUuid}"""`,
+        `<${bestuurseenheidId}> <http://www.w3.org/2004/02/skos/core#prefLabel> """preferred label"""`,
+        `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>`,
+        `<${bestuurseenheidId}> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <${werkingsgebied1Id}>`,
+        `<${werkingsgebied1Id}> <http://www.w3.org/2004/02/skos/core#exactMatch> <${spatial1Id}>`,
+      ]);
+
+      const actualBestuurseenheid =
+        await repository.findById(bestuurseenheidId);
+
+      expect(actualBestuurseenheid.spatials).toEqual([]);
+    });
+  });
+
+  describe("map bestuurseenheidClassificatieCode to uri", () => {
+    test("Check that all bestuurseenheid classification codes can get mapped. ", () => {
+      const classificatieCodes = Object.keys(BestuurseenheidClassificatieCode);
+
+      classificatieCodes.forEach((code) => {
+        expect(
+          repository.mapBestuurseenheidClassificatieCodeToUri(
+            BestuurseenheidClassificatieCode[code],
+          ),
+        ).toEqual(BestuurseenheidClassificatieCodeUri[code]);
+      });
+    });
+
+    test("Non matched bestuurseenheid classification code throws error. ", () => {
+      const nonExistingClassificationCode =
+        "non-existing" as BestuurseenheidClassificatieCode;
+      expect(() =>
+        repository.mapBestuurseenheidClassificatieCodeToUri(
+          nonExistingClassificationCode,
+        ),
+      ).toThrowWithMessage(
+        NotFoundError,
+        `No classification code uri found for: ${nonExistingClassificationCode}`,
+      );
+    });
+
+    test("Enum of BestuurseenheidClassificatieCode and BestuurseenheidClassificatieCode should contain the same amount of elements   ", () => {
+      const classificatieCodeCount = Object.keys(
+        BestuurseenheidClassificatieCode,
+      ).length;
+      const classificatieCodeUrisCount = Object.keys(
+        BestuurseenheidClassificatieCodeUri,
+      ).length;
+
+      expect(classificatieCodeCount).toBe(classificatieCodeUrisCount);
+    });
+  });
+
+  describe("map bestuurseenheidClassificatieUri to code", () => {
+    test("Check that all bestuurseenheid classification uris can get mapped. ", () => {
+      const classificatieCodesUri = Object.keys(
+        BestuurseenheidClassificatieCodeUri,
+      );
+
+      classificatieCodesUri.forEach((code) => {
+        expect(
+          repository.mapBestuurseenheidClassificatieUriToCode(
+            BestuurseenheidClassificatieCodeUri[code],
+          ),
+        ).toEqual(BestuurseenheidClassificatieCode[code]);
+      });
+    });
+
+    test("Non matched bestuurseenheid classification uri throws error. ", () => {
+      const nonExistingClassificationUri =
+        "non-existing" as BestuurseenheidClassificatieCodeUri;
+      expect(() =>
+        repository.mapBestuurseenheidClassificatieUriToCode(
+          nonExistingClassificationUri,
+        ),
+      ).toThrowWithMessage(
+        NotFoundError,
+        `Geen classificatiecode gevonden voor: ${nonExistingClassificationUri}`,
+      );
+    });
+  });
 });

--- a/test/driven/persistence/bestuurseenheid-sparql-test-repository.ts
+++ b/test/driven/persistence/bestuurseenheid-sparql-test-repository.ts
@@ -1,25 +1,32 @@
 import {
-    BestuurseenheidClassificatieCodeUri,
-    BestuurseenheidSparqlRepository
+  BestuurseenheidClassificatieCodeUri,
+  BestuurseenheidSparqlRepository,
 } from "../../../src/driven/persistence/bestuurseenheid-sparql-repository";
-import {Bestuurseenheid, BestuurseenheidClassificatieCode} from "../../../src/core/domain/bestuurseenheid";
-import {PREFIX, PUBLIC_GRAPH} from "../../../config";
-import {sparqlEscapeString, sparqlEscapeUri, uuid} from "../../../mu-helper";
-import {buildWerkingsgebiedenIri} from "../../core/domain/iri-test-builder";
-import {NotFoundError} from "../../../src/core/domain/shared/lpdc-error";
+import {
+  Bestuurseenheid,
+  BestuurseenheidClassificatieCode,
+} from "../../../src/core/domain/bestuurseenheid";
+import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { sparqlEscapeString, sparqlEscapeUri, uuid } from "../../../mu-helper";
+import { buildWerkingsgebiedenIri } from "../../core/domain/iri-test-builder";
+import { NotFoundError } from "../../../src/core/domain/shared/lpdc-error";
 
 export class BestuurseenheidSparqlTestRepository extends BestuurseenheidSparqlRepository {
+  constructor(endpoint?: string) {
+    super(endpoint);
+  }
 
-    constructor(endpoint?: string) {
-        super(endpoint);
-    }
+  async save(bestuurseenheid: Bestuurseenheid): Promise<void> {
+    const classificatieUri = this.mapBestuurseenheidClassificatieCodeToUri(
+      bestuurseenheid.classificatieCode,
+    );
 
-    async save(bestuurseenheid: Bestuurseenheid): Promise<void> {
-        const classificatieUri = this.mapBestuurseenheidClassificatieCodeToUri(bestuurseenheid.classificatieCode);
+    const werkingsgebiedenSpatials = bestuurseenheid.spatials.map((sp) => [
+      sp,
+      buildWerkingsgebiedenIri(uuid()),
+    ]);
 
-        const werkingsgebiedenSpatials = bestuurseenheid.spatials.map(sp => [sp, buildWerkingsgebiedenIri(uuid())]);
-
-        const query = `
+    const query = `
             ${PREFIX.skos}
             ${PREFIX.besluit}
             ${PREFIX.mu}
@@ -30,32 +37,40 @@ export class BestuurseenheidSparqlTestRepository extends BestuurseenheidSparqlRe
                 GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {
                     ${sparqlEscapeUri(bestuurseenheid.id)} a besluit:Bestuurseenheid .
                     ${sparqlEscapeUri(bestuurseenheid.id)} skos:prefLabel ${sparqlEscapeString(bestuurseenheid.prefLabel)} .
-                    ${classificatieUri ? `${sparqlEscapeUri(bestuurseenheid.id)} besluit:classificatie ${sparqlEscapeUri(classificatieUri)} .` : ''}
+                    ${classificatieUri ? `${sparqlEscapeUri(bestuurseenheid.id)} besluit:classificatie ${sparqlEscapeUri(classificatieUri)} .` : ""}
                     ${sparqlEscapeUri(bestuurseenheid.id)} mu:uuid ${sparqlEscapeString(bestuurseenheid.uuid)} .
-                    ${werkingsgebiedenSpatials.flatMap(wgs => [
+                    ${werkingsgebiedenSpatials
+                      .flatMap((wgs) => [
                         `${sparqlEscapeUri(bestuurseenheid.id)} besluit:werkingsgebied ${sparqlEscapeUri(wgs[1])}`,
                         `${sparqlEscapeUri(wgs[1])} skos:exactMatch ${sparqlEscapeUri(wgs[0])}`,
-                        `${sparqlEscapeUri(wgs[0])} skos:inScheme nutss:2021`,
-        ]).join(' .\n')} .
+                        `${sparqlEscapeUri(wgs[0])} skos:inScheme nutss:2024`,
+                      ])
+                      .join(" .\n")} .
                 }
             }
         `;
-        await this.querying.insert(query);
+    await this.querying.insert(query);
+  }
+
+  mapBestuurseenheidClassificatieCodeToUri(
+    classificatieCode: BestuurseenheidClassificatieCode | undefined,
+  ): BestuurseenheidClassificatieCodeUri | undefined {
+    if (!classificatieCode) {
+      return undefined;
     }
+    const key: string | undefined = Object.keys(
+      BestuurseenheidClassificatieCode,
+    ).find(
+      (key) => BestuurseenheidClassificatieCode[key] === classificatieCode,
+    );
 
-    mapBestuurseenheidClassificatieCodeToUri(classificatieCode: BestuurseenheidClassificatieCode | undefined): BestuurseenheidClassificatieCodeUri | undefined {
-        if (!classificatieCode) {
-            return undefined;
-        }
-        const key: string | undefined = Object.keys(BestuurseenheidClassificatieCode)
-            .find(key => BestuurseenheidClassificatieCode[key] === classificatieCode);
+    const classificatieCodeUri = BestuurseenheidClassificatieCodeUri[key];
 
-        const classificatieCodeUri = BestuurseenheidClassificatieCodeUri[key];
-
-        if (!classificatieCodeUri) {
-            throw new NotFoundError(`No classification code uri found for: ${classificatieCode}`);
-        }
-        return classificatieCodeUri;
+    if (!classificatieCodeUri) {
+      throw new NotFoundError(
+        `No classification code uri found for: ${classificatieCode}`,
+      );
     }
-
+    return classificatieCodeUri;
+  }
 }


### PR DESCRIPTION
The NUTS LAU code list stored in the backend has been updated to the new 2024
scheme.

This updates
- the form query for the geographical scope field to use the new scheme
- the functionality to find administrative units by id (and its corresponding
  tests)


This PR should be tested against https://github.com/lblod/app-lpdc-digitaal-loket/pull/34

## Related tickets
LPDC-1261