### PR TITLE
Extend data migrations scripts

### DIFF
--- a/migration-scripts/transfer-instances/archive-instances-script.ts
+++ b/migration-scripts/transfer-instances/archive-instances-script.ts
@@ -1,13 +1,13 @@
-import {sparqlEscapeDateTime, sparqlEscapeUri, uuid} from "../../mu-helper";
-import {Iri} from "../../src/core/domain/shared/iri";
-import {InstanceSparqlRepository} from "../../src/driven/persistence/instance-sparql-repository";
+import { sparqlEscapeDateTime, sparqlEscapeUri, uuid } from "../../mu-helper";
+import { Iri } from "../../src/core/domain/shared/iri";
+import { InstanceSparqlRepository } from "../../src/driven/persistence/instance-sparql-repository";
 import fs from "fs";
-import {BestuurseenheidSparqlRepository} from "../../src/driven/persistence/bestuurseenheid-sparql-repository";
-import {DomainToQuadsMapper} from "../../src/driven/persistence/domain-to-quads-mapper";
-import {Bestuurseenheid} from "../../src/core/domain/bestuurseenheid";
-import {PublishedInstanceSnapshotBuilder} from "../../src/core/domain/published-instance-snapshot";
-import {PREFIX} from "../../config";
-import {DirectDatabaseAccess} from "../../test/driven/persistence/direct-database-access";
+import { BestuurseenheidSparqlRepository } from "../../src/driven/persistence/bestuurseenheid-sparql-repository";
+import { DomainToQuadsMapper } from "../../src/driven/persistence/domain-to-quads-mapper";
+import { Bestuurseenheid } from "../../src/core/domain/bestuurseenheid";
+import { PublishedInstanceSnapshotBuilder } from "../../src/core/domain/published-instance-snapshot";
+import { PREFIX } from "../../config";
+import { DirectDatabaseAccess } from "../../test/driven/persistence/direct-database-access";
 
 const endPoint = process.env.SPARQL_URL;
 
@@ -15,34 +15,44 @@ const directDatabaseAccess = new DirectDatabaseAccess(endPoint);
 const bestuurseenheidRepository = new BestuurseenheidSparqlRepository(endPoint);
 const instanceRepository = new InstanceSparqlRepository(endPoint);
 
-
 async function main(bestuurseenheidId: Iri) {
-    const insertTriples = [];
-    const deleteTriples = [];
-    const bestuurseenheid = await bestuurseenheidRepository.findById(bestuurseenheidId);
+  const insertTriples = [];
+  const deleteTriples = [];
+  const bestuurseenheid =
+    await bestuurseenheidRepository.findById(bestuurseenheidId);
 
-    const domainToQuadsMerger = new DomainToQuadsMapper(bestuurseenheid.userGraph());
+  const domainToQuadsMerger = new DomainToQuadsMapper(
+    bestuurseenheid.userGraph(),
+  );
 
-    const instanceIds: Iri[] = await getAllInstanceIdsForBestuurseenheid(bestuurseenheid);
+  const instanceIds: Iri[] =
+    await getAllInstanceIdsForBestuurseenheid(bestuurseenheid);
 
+  console.log(`Instances to archive: ${instanceIds.length}`);
+  for (const instanceId of instanceIds) {
+    const instance = await instanceRepository.findById(
+      bestuurseenheid,
+      instanceId,
+    );
 
-    console.log(`Instances to archive: ${instanceIds.length}`);
-    for (const instanceId of instanceIds) {
-        const instance = await instanceRepository.findById(bestuurseenheid, instanceId);
-
-        if (instance.dateSent !== undefined) {
-            const triples = tombstoneQuads(instance.id.value);
-            insertTriples.push(triples);
-        }
-
-        const triplesToDelete = domainToQuadsMerger.instanceToQuads(instance).map(quad => quad.toNT()).join('\n');
-        deleteTriples.push(triplesToDelete);
+    if (instance.dateSent !== undefined) {
+      const triples = tombstoneQuads(instance.id.value);
+      insertTriples.push(triples);
     }
-    createSparql(bestuurseenheid, insertTriples, deleteTriples);
+
+    const triplesToDelete = domainToQuadsMerger
+      .instanceToQuads(instance)
+      .map((quad) => quad.toNT())
+      .join("\n");
+    deleteTriples.push(triplesToDelete);
+  }
+  createSparql(bestuurseenheid, insertTriples, deleteTriples);
 }
 
-async function getAllInstanceIdsForBestuurseenheid(bestuurseenheid: Bestuurseenheid): Promise<Iri[]> {
-    const query = `
+async function getAllInstanceIdsForBestuurseenheid(
+  bestuurseenheid: Bestuurseenheid,
+): Promise<Iri[]> {
+  const query = `
             ${PREFIX.lpdcExt}
             SELECT ?id WHERE {
                 GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {
@@ -50,47 +60,54 @@ async function getAllInstanceIdsForBestuurseenheid(bestuurseenheid: Bestuurseenh
                 }
             }
             `;
-    const instanceIds = await directDatabaseAccess.list(query);
-    return instanceIds.map(instanceId => new Iri(instanceId['id'].value));
+  const instanceIds = await directDatabaseAccess.list(query);
+  return instanceIds.map((instanceId) => new Iri(instanceId["id"].value));
 }
 
 function tombstoneQuads(instanceId: string) {
+  const uniqueId = uuid();
+  const tombstoneId = PublishedInstanceSnapshotBuilder.buildIri(uniqueId);
 
-    const uniqueId = uuid();
-    const tombstoneId = PublishedInstanceSnapshotBuilder.buildIri(uniqueId);
+  const tombstoneQuads = [];
+  const now = new Date();
+  tombstoneQuads.push(
+    `${sparqlEscapeUri(tombstoneId)} a <https://www.w3.org/ns/activitystreams#Tombstone> .`,
+  );
+  tombstoneQuads.push(
+    `${sparqlEscapeUri(tombstoneId)} <https://www.w3.org/ns/activitystreams#formerType> <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#InstancePublicService> .`,
+  );
+  tombstoneQuads.push(
+    `${sparqlEscapeUri(tombstoneId)} <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#isPublishedVersionOf> ${sparqlEscapeUri(instanceId)} .`,
+  );
+  tombstoneQuads.push(
+    `${sparqlEscapeUri(tombstoneId)} <https://www.w3.org/ns/activitystreams#deleted> ${sparqlEscapeDateTime(now)} .`,
+  );
+  tombstoneQuads.push(
+    `${sparqlEscapeUri(tombstoneId)} <http://www.w3.org/ns/prov#generatedAtTime> ${sparqlEscapeDateTime(now)} .`,
+  );
 
-
-    const tombstoneQuads = [];
-    const now = new Date();
-    tombstoneQuads.push(`${sparqlEscapeUri(tombstoneId)} a <https://www.w3.org/ns/activitystreams#Tombstone> .`);
-    tombstoneQuads.push(`${sparqlEscapeUri(tombstoneId)} <https://www.w3.org/ns/activitystreams#formerType> <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#InstancePublicService> .`);
-    tombstoneQuads.push(`${sparqlEscapeUri(tombstoneId)} <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#isPublishedVersionOf> ${sparqlEscapeUri(instanceId)} .`);
-    tombstoneQuads.push(`${sparqlEscapeUri(tombstoneId)} <https://www.w3.org/ns/activitystreams#deleted> ${sparqlEscapeDateTime(now)} .`);
-    tombstoneQuads.push(`${sparqlEscapeUri(tombstoneId)} <http://www.w3.org/ns/prov#generatedAtTime> ${sparqlEscapeDateTime(now)} .`);
-
-
-    return tombstoneQuads.join(`\n`);
+  return tombstoneQuads.join(`\n`);
 }
 
-function createSparql(bestuurseenheid: Bestuurseenheid, insertTriples: string[], deleteTriples: string[]) {
-    const query = `
-        
+function createSparql(
+  bestuurseenheid: Bestuurseenheid,
+  insertTriples: string[],
+  deleteTriples: string[],
+) {
+  const query = `
         WITH ${sparqlEscapeUri(bestuurseenheid.userGraph())}
         DELETE {
-            ${deleteTriples.join("\n")}                        
-        }            
-        INSERT { 
-            ${insertTriples.join("\n")}        
-        }     
-        WHERE {
-            
+            ${deleteTriples.join("\n")}
         }
-           
+        INSERT {
+            ${insertTriples.join("\n")}
+        }
+        WHERE {
+        }
         `;
 
-    fs.writeFileSync(`./migration-results/archive-instances.sparql`, query);
+  fs.writeFileSync(`./migration-results/archive-instances.sparql`, query);
 }
-
 
 const bestuurseenheid = new Iri("");
 

--- a/migration-scripts/transfer-instances/archive-instances-script.ts
+++ b/migration-scripts/transfer-instances/archive-instances-script.ts
@@ -8,6 +8,7 @@ import { Bestuurseenheid } from "../../src/core/domain/bestuurseenheid";
 import { PublishedInstanceSnapshotBuilder } from "../../src/core/domain/published-instance-snapshot";
 import { PREFIX } from "../../config";
 import { DirectDatabaseAccess } from "../../test/driven/persistence/direct-database-access";
+import { buildFilename } from "./util";
 
 const endPoint = process.env.SPARQL_URL;
 
@@ -15,20 +16,29 @@ const directDatabaseAccess = new DirectDatabaseAccess(endPoint);
 const bestuurseenheidRepository = new BestuurseenheidSparqlRepository(endPoint);
 const instanceRepository = new InstanceSparqlRepository(endPoint);
 
-async function main(bestuurseenheidId: Iri) {
+async function archiveProductInstances(
+  bestuurseenheidId: Iri,
+  keepMunicipalityMergerInstances: boolean,
+) {
   const insertTriples = [];
   const deleteTriples = [];
   const bestuurseenheid =
     await bestuurseenheidRepository.findById(bestuurseenheidId);
 
+  console.log(`Generating archive migration for ${bestuurseenheid.prefLabel}`);
+
   const domainToQuadsMerger = new DomainToQuadsMapper(
     bestuurseenheid.userGraph(),
   );
 
-  const instanceIds: Iri[] =
-    await getAllInstanceIdsForBestuurseenheid(bestuurseenheid);
+  const instanceIds: Iri[] = keepMunicipalityMergerInstances
+    ? await getAllInstanceIdsWithoutMunicipalityMergerForBestuurseenheid(
+        bestuurseenheid,
+      )
+    : await getAllInstanceIdsForBestuurseenheid(bestuurseenheid);
 
   console.log(`Instances to archive: ${instanceIds.length}`);
+
   for (const instanceId of instanceIds) {
     const instance = await instanceRepository.findById(
       bestuurseenheid,
@@ -46,6 +56,7 @@ async function main(bestuurseenheidId: Iri) {
       .join("\n");
     deleteTriples.push(triplesToDelete);
   }
+
   createSparql(bestuurseenheid, insertTriples, deleteTriples);
 }
 
@@ -64,12 +75,29 @@ async function getAllInstanceIdsForBestuurseenheid(
   return instanceIds.map((instanceId) => new Iri(instanceId["id"].value));
 }
 
+async function getAllInstanceIdsWithoutMunicipalityMergerForBestuurseenheid(
+  bestuurseenheid: Bestuurseenheid,
+): Promise<Iri[]> {
+  const query = `
+            ${PREFIX.lpdcExt}
+            SELECT ?id WHERE {
+                GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {
+                    ?id a lpdcExt:InstancePublicService .
+                    ?id lpdcExt:forMunicipalityMerger """false"""^^<http://www.w3.org/2001/XMLSchema#boolean>
+                }
+            }
+            `;
+
+  const instanceIds = await directDatabaseAccess.list(query);
+  return instanceIds.map((instanceId) => new Iri(instanceId["id"].value));
+}
+
 function tombstoneQuads(instanceId: string) {
   const uniqueId = uuid();
   const tombstoneId = PublishedInstanceSnapshotBuilder.buildIri(uniqueId);
-
   const tombstoneQuads = [];
   const now = new Date();
+
   tombstoneQuads.push(
     `${sparqlEscapeUri(tombstoneId)} a <https://www.w3.org/ns/activitystreams#Tombstone> .`,
   );
@@ -94,21 +122,62 @@ function createSparql(
   insertTriples: string[],
   deleteTriples: string[],
 ) {
-  const query = `
-        WITH ${sparqlEscapeUri(bestuurseenheid.userGraph())}
-        DELETE {
-            ${deleteTriples.join("\n")}
-        }
-        INSERT {
-            ${insertTriples.join("\n")}
-        }
-        WHERE {
-        }
-        `;
+  let query = "";
 
-  fs.writeFileSync(`./migration-results/archive-instances.sparql`, query);
+  if (deleteTriples.length > 0) {
+    query += `DELETE DATA {\n
+    GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {\n
+      ${deleteTriples.join("\n")}
+    }\n
+    }\n`;
+  }
+
+  if (deleteTriples.length > 0 && insertTriples.length > 0) {
+    query += ";\n";
+  }
+
+  if (insertTriples.length > 0) {
+    query += `INSERT DATA {
+    GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {\n
+      ${insertTriples.join("\n")}
+    }\n
+    }`;
+  }
+
+  const filename = buildFilename(
+    "archive-instances",
+    bestuurseenheid.prefLabel,
+  );
+
+  if (deleteTriples.length > 0 || insertTriples.length > 0) {
+    fs.writeFileSync(`./migration-results/${filename}.sparql`, query);
+    console.log(`Wrote migration to ${filename}`);
+  } else {
+    console.log("No triples to delete or insert, no migration written");
+  }
 }
 
-const bestuurseenheid = new Iri("");
+// Specify for which administrative unit the product instances should be
+// archived
+type Configuration = {
+  // URI of the administrative unit
+  uri: string;
+  // An optional boolean to indicate that only product instance that are *not*
+  // labelled for merger should be archived
+  keepMunicipalityMergerInstances?: boolean;
+};
 
-main(bestuurseenheid);
+const archiveConfigurations: Configuration[] = [
+  {
+    uri: "",
+  },
+];
+
+for (const conf of archiveConfigurations) {
+  archiveProductInstances(
+    new Iri(conf.uri),
+    conf.keepMunicipalityMergerInstances
+      ? conf.keepMunicipalityMergerInstances
+      : false,
+  );
+}

--- a/migration-scripts/transfer-instances/readme.md
+++ b/migration-scripts/transfer-instances/readme.md
@@ -1,40 +1,57 @@
 # Transfer Instances
 
-## Transfer instances to new authority
+## Optional: before first usage of scripts
 
-- create a .env file like .env-example and fill in the **SPARQL_URL** && **ADRESSEN_REGISTER_API_KEY**
+Install the necessary dependencies:
 
-- Execute [transfer-instances-script](transfer-instances-script.ts) by running the script
-  - **FromAuthority**: The authority from which we transfer the instances
-  - **ToAuthority**: The authority where we transfer the instances to
-  - **onlyForMunicipalityMergerInstances**:
-    - If true, only merge instances where the forMunicipalityMerger is true
-    - If false, merge all instances
+```shell
+  npm install
+```
 
+Create the folder to which the generated migrations are written:
+
+```shell
+  mkdir migration-results
+```
+
+Create a `.env` file like `.env-example` and fill in the **SPARQL_URL** && **ADRESSEN_REGISTER_API_KEY**
+
+## Boot LPDC stack
+
+Before executing any of the scripts, ensure at least LPDC's virtuoso service is running and accessible via the above **SPARQL_URL**.
+
+## Generate migrations to transfer product instances to new authority
+
+The [transfer-instances-script](transfer-instances-script.ts) generates migrations to copy product instances from one organisation to another. Note that it is allowed to use the same organisation as source and destination. The script generates two kinds of migrations:
+- one TTL migration per source and destination organisation pair. Such migrations insert a deep copy of each (or a subset of) product instance(s) of the source organisation into the graph for the source organisation.
+- if only a subset of product instances is transferred, a second migration is generated to disable the merger label for the source product instances.
+
+### Usage
+
+- Configure [transfer-instances-script](transfer-instances-script.ts) by adding a `Configuration` for each product instances transfer that should be generated. See the `Configuration` type definition in the script for more details.
+- Execute the script by running the following command in this folder
 ```shell
   npm run transfer-instances
 ```
+- Execute the generated migrations found in `./migration-results/`, by placing them in the app's migration folder and (re)starting the `migrations` service.
 
-- Upload the generated  [transfer-instances.ttl](migration-results/transfer-instances.ttl)
+## Generate migrations to archive product instances
 
-### Update concept display configurations
+The [archive-instances-script](archive-instances-script.ts) generates SPARQL migrations that for a given organisation:
+- marks all sent product instances as archived, such that this state can be forwarded to IPDC.
+- deletes all product instances from the LPDC app.
 
-Follow the steps
-in [display-configuratie-andere-besturen](https://github.com/lblod/app-lpdc-digitaal-loket/tree/development/migration-scripts/display-configuratie-andere-besturen)
-in app-lpdc-digitaal-loket
 
-## Archive initial instances
-
-- Execute [archive-instances-script](archive-instances-script.ts)
-
+### Usage
+- Add a `Configuration` entry for each organisation for which the product instances must be archived. See the `Configuration` type and `archiveConfigurations` constant at the end of [archive-instances-script](archive-instances-script.ts) for more details.
+- Execute the script by running the following command in this folder
 ```shell
   npm run archive-instances
 ```
+- Execute the generated migrations found in `./migration-results/`, by placing them in the app's migration folder and (re)starting the `migrations` service.
 
-- Execute generated [archive-instance](migration-results/archive-instances.sparql)
-
-### Update concept display configurations
+## Update concept display
 
 Follow the steps
 in [display-configuratie-andere-besturen](https://github.com/lblod/app-lpdc-digitaal-loket/tree/development/migration-scripts/display-configuratie-andere-besturen)
-in app-lpdc-digitaal-loket
+to update the stores display configurations.

--- a/migration-scripts/transfer-instances/transfer-instance-service.ts
+++ b/migration-scripts/transfer-instances/transfer-instance-service.ts
@@ -1,102 +1,171 @@
-import {Instance, InstanceBuilder} from "../../src/core/domain/instance";
-import {BestuurseenheidRepository} from "../../src/core/port/driven/persistence/bestuurseenheid-repository";
-import {Iri} from "../../src/core/domain/shared/iri";
-import {InstanceRepository} from "../../src/core/port/driven/persistence/instance-repository";
-import {FormalInformalChoiceRepository} from "../../src/core/port/driven/persistence/formal-informal-choice-repository";
-import {ChosenFormType, CompetentAuthorityLevelType, InstanceStatusType} from "../../src/core/domain/types";
-import {InvariantError} from "../../src/core/domain/shared/lpdc-error";
-import {uuid} from "../../mu-helper";
-import {Language} from "../../src/core/domain/language";
-import {FormatPreservingDate} from "../../src/core/domain/format-preserving-date";
-import {ContactPoint, ContactPointBuilder} from "../../src/core/domain/contact-point";
-import {AddressFetcher} from "../../src/core/port/driven/external/address-fetcher";
-import {AddressBuilder} from "../../src/core/domain/address";
-import {LanguageString} from "../../src/core/domain/language-string";
-import {Bestuurseenheid} from "../../src/core/domain/bestuurseenheid";
-import {AddressTestBuilder} from "../../test/core/domain/address-test-builder";
+import { Instance, InstanceBuilder } from "../../src/core/domain/instance";
+import { BestuurseenheidRepository } from "../../src/core/port/driven/persistence/bestuurseenheid-repository";
+import { Iri } from "../../src/core/domain/shared/iri";
+import { InstanceRepository } from "../../src/core/port/driven/persistence/instance-repository";
+import { FormalInformalChoiceRepository } from "../../src/core/port/driven/persistence/formal-informal-choice-repository";
+import {
+  ChosenFormType,
+  CompetentAuthorityLevelType,
+  InstanceStatusType,
+} from "../../src/core/domain/types";
+import { InvariantError } from "../../src/core/domain/shared/lpdc-error";
+import { uuid } from "../../mu-helper";
+import { Language } from "../../src/core/domain/language";
+import { FormatPreservingDate } from "../../src/core/domain/format-preserving-date";
+import {
+  ContactPoint,
+  ContactPointBuilder,
+} from "../../src/core/domain/contact-point";
+import { AddressFetcher } from "../../src/core/port/driven/external/address-fetcher";
+import { AddressBuilder } from "../../src/core/domain/address";
+import { LanguageString } from "../../src/core/domain/language-string";
+import { Bestuurseenheid } from "../../src/core/domain/bestuurseenheid";
+import { AddressTestBuilder } from "../../test/core/domain/address-test-builder";
 
 export class TransferInstanceService {
+  private readonly bestuurseenheidRepository: BestuurseenheidRepository;
+  private readonly instanceRepository: InstanceRepository;
+  private formalInformalChoiceRepository: FormalInformalChoiceRepository;
+  private addressFetcher: AddressFetcher;
 
-    private readonly bestuurseenheidRepository: BestuurseenheidRepository;
-    private readonly instanceRepository: InstanceRepository;
-    private formalInformalChoiceRepository: FormalInformalChoiceRepository;
-    private addressFetcher: AddressFetcher;
+  constructor(
+    bestuurseenheidRepository: BestuurseenheidRepository,
+    instanceRepository: InstanceRepository,
+    formalInformalChoiceRepository: FormalInformalChoiceRepository,
+    addressFetcher: AddressFetcher,
+  ) {
+    this.bestuurseenheidRepository = bestuurseenheidRepository;
+    this.instanceRepository = instanceRepository;
+    this.formalInformalChoiceRepository = formalInformalChoiceRepository;
+    this.addressFetcher = addressFetcher;
+  }
 
-    constructor(bestuurseenheidRepository: BestuurseenheidRepository, instanceRepository: InstanceRepository, formalInformalChoiceRepository: FormalInformalChoiceRepository, addressFetcher: AddressFetcher) {
-        this.bestuurseenheidRepository = bestuurseenheidRepository;
-        this.instanceRepository = instanceRepository;
-        this.formalInformalChoiceRepository = formalInformalChoiceRepository;
-        this.addressFetcher = addressFetcher;
+  async transfer(
+    instanceId: Iri,
+    fromAuthority: Bestuurseenheid,
+    toAuthority: Bestuurseenheid,
+  ): Promise<Instance> {
+    const toAuthorityChoice = (
+      await this.formalInformalChoiceRepository.findByBestuurseenheid(
+        toAuthority,
+      )
+    )?.chosenForm;
+
+    const instance: Instance = await this.instanceRepository.findById(
+      fromAuthority,
+      instanceId,
+    );
+
+    if (
+      toAuthorityChoice === ChosenFormType.FORMAL &&
+      instance.dutchLanguageVariant === Language.INFORMAL
+    ) {
+      throw new InvariantError(
+        "transforming informal instance to formal is not possible",
+      );
     }
+    return this.transferInstance(toAuthority.id, toAuthorityChoice, instance);
+  }
 
-    async transfer(instanceId: Iri, fromAuthority: Bestuurseenheid, toAuthority: Bestuurseenheid): Promise<Instance> {
+  private async transferInstance(
+    toAuthorityId: Iri,
+    toAuthorityChoice: ChosenFormType,
+    instanceToCopy: Instance,
+  ) {
+    const instanceUuid = uuid();
+    const instanceId = InstanceBuilder.buildIri(instanceUuid);
 
-        const toAuthorityChoice = (await this.formalInformalChoiceRepository.findByBestuurseenheid(toAuthority))?.chosenForm;
+    const hasCompetentAuthorityLevelLokaal =
+      instanceToCopy.competentAuthorityLevels.includes(
+        CompetentAuthorityLevelType.LOKAAL,
+      );
+    const needsConversionFromFormalToInformal =
+      toAuthorityChoice === ChosenFormType.INFORMAL &&
+      instanceToCopy.dutchLanguageVariant !== Language.INFORMAL;
 
-        const instance: Instance = await this.instanceRepository.findById(fromAuthority, instanceId);
+    const contactpointsWithUpdatedAddresses =
+      await this.mapAddressesForContactpoints(instanceToCopy.contactPoints);
 
-        if (toAuthorityChoice === ChosenFormType.FORMAL && instance.dutchLanguageVariant === Language.INFORMAL) {
-            throw new InvariantError("transforming informal instance to formal is not possible");
-        }
-        return this.transferInstance(toAuthority.id, toAuthorityChoice, instance);
+    return InstanceBuilder.from(instanceToCopy)
+      .withId(instanceId)
+      .withUuid(instanceUuid)
+      .withCreatedBy(toAuthorityId)
+      .withDateCreated(FormatPreservingDate.now())
+      .withDateModified(FormatPreservingDate.now())
+      .withRequirements(
+        instanceToCopy.requirements.map((req) => req.transformWithNewId()),
+      )
+      .withProcedures(
+        instanceToCopy.procedures.map((proc) => proc.transformWithNewId()),
+      )
+      .withWebsites(
+        instanceToCopy.websites.map((ws) => ws.transformWithNewId()),
+      )
+      .withCosts(instanceToCopy.costs.map((c) => c.transformWithNewId()))
+      .withFinancialAdvantages(
+        instanceToCopy.financialAdvantages.map((fa) => fa.transformWithNewId()),
+      )
+      .withContactPoints(
+        contactpointsWithUpdatedAddresses.map((fa) => fa.transformWithNewId()),
+      )
+      .withStatus(InstanceStatusType.ONTWERP)
+      .withDateSent(undefined)
+      .withNeedsConversionFromFormalToInformal(
+        needsConversionFromFormalToInformal,
+      )
+      .withLegalResources(
+        instanceToCopy.legalResources.map((lr) => lr.transformWithNewId()),
+      )
 
-    }
+      .withSpatials(
+        instanceToCopy.forMunicipalityMerger ? instanceToCopy.spatials : [],
+      )
+      .withExecutingAuthorities(
+        instanceToCopy.forMunicipalityMerger
+          ? instanceToCopy.executingAuthorities
+          : [],
+      )
+      .withCompetentAuthorities(
+        !instanceToCopy.forMunicipalityMerger &&
+          hasCompetentAuthorityLevelLokaal
+          ? []
+          : instanceToCopy.competentAuthorities,
+      )
+      .withForMunicipalityMerger(false)
+      .withCopyOf(undefined)
+      .build();
+  }
 
-    private async transferInstance(toAuthorityId: Iri, toAuthorityChoice: ChosenFormType, instanceToCopy: Instance) {
-        const instanceUuid = uuid();
-        const instanceId = InstanceBuilder.buildIri(instanceUuid);
+  private async mapAddressesForContactpoints(
+    contactPoints: ContactPoint[],
+  ): Promise<ContactPoint[]> {
+    const fetchAddressMatch = async (cp: ContactPoint) => {
+      const address = cp.address;
+      if (address?.gemeentenaam && address?.straatnaam && address?.huisnummer) {
+        const match = await this.addressFetcher.findAddressMatch(
+          address.gemeentenaam?.nl,
+          address.straatnaam?.nl,
+          address.huisnummer,
+          address.busnummer,
+        );
+        const updatedAddress = AddressBuilder.from(address)
+          .withPostcode(match["postcode"] ? match["postcode"] : undefined)
+          .withVerwijstNaar(
+            match["adressenRegisterId"]
+              ? new Iri(match["adressenRegisterId"])
+              : undefined,
+          )
+          .withLand(
+            match["adressenRegisterId"]
+              ? LanguageString.of(AddressTestBuilder.LAND)
+              : undefined,
+          )
+          .build();
+        return ContactPointBuilder.from(cp).withAddress(updatedAddress).build();
+      }
+      return cp;
+    };
 
-        const hasCompetentAuthorityLevelLokaal = instanceToCopy.competentAuthorityLevels.includes(CompetentAuthorityLevelType.LOKAAL);
-        const needsConversionFromFormalToInformal = (toAuthorityChoice === ChosenFormType.INFORMAL && instanceToCopy.dutchLanguageVariant !== Language.INFORMAL);
-
-        const contactpointsWithUpdatedAddresses = await this.mapAddressesForContactpoints(instanceToCopy.contactPoints);
-
-
-        return InstanceBuilder.from(instanceToCopy)
-            .withId(instanceId)
-            .withUuid(instanceUuid)
-            .withCreatedBy(toAuthorityId)
-            .withDateCreated(FormatPreservingDate.now())
-            .withDateModified(FormatPreservingDate.now())
-            .withRequirements(instanceToCopy.requirements.map(req => req.transformWithNewId()))
-            .withProcedures(instanceToCopy.procedures.map(proc => proc.transformWithNewId()))
-            .withWebsites(instanceToCopy.websites.map(ws => ws.transformWithNewId()))
-            .withCosts(instanceToCopy.costs.map(c => c.transformWithNewId()))
-            .withFinancialAdvantages(instanceToCopy.financialAdvantages.map(fa => fa.transformWithNewId()))
-            .withContactPoints(contactpointsWithUpdatedAddresses.map(fa => fa.transformWithNewId()))
-            .withStatus(InstanceStatusType.ONTWERP)
-            .withDateSent(undefined)
-            .withNeedsConversionFromFormalToInformal(needsConversionFromFormalToInformal)
-            .withLegalResources(instanceToCopy.legalResources.map(lr => lr.transformWithNewId()))
-            .withSpatials(instanceToCopy.forMunicipalityMerger ? instanceToCopy.spatials : [])
-            .withExecutingAuthorities(instanceToCopy.forMunicipalityMerger ? instanceToCopy.executingAuthorities : [])
-            .withCompetentAuthorities(!instanceToCopy.forMunicipalityMerger && hasCompetentAuthorityLevelLokaal ? [] : instanceToCopy.competentAuthorities)
-            .withForMunicipalityMerger(false)
-            .withCopyOf(undefined)
-            .build();
-    }
-
-    private async mapAddressesForContactpoints(contactPoints: ContactPoint[]): Promise<ContactPoint[]> {
-        const fetchAddressMatch = async (cp: ContactPoint) => {
-            const address = cp.address;
-            if (address?.gemeentenaam && address?.straatnaam && address?.huisnummer) {
-                const match = await this.addressFetcher.findAddressMatch(
-                    address.gemeentenaam?.nl,
-                    address.straatnaam?.nl,
-                    address.huisnummer,
-                    address.busnummer
-                );
-                const updatedAddress = AddressBuilder.from(address)
-                    .withPostcode(match['postcode'] ? match['postcode'] : undefined)
-                    .withVerwijstNaar(match['adressenRegisterId'] ? new Iri(match['adressenRegisterId']) : undefined)
-                    .withLand(match['adressenRegisterId'] ? LanguageString.of(AddressTestBuilder.LAND) : undefined)
-                    .build();
-                return ContactPointBuilder.from(cp).withAddress(updatedAddress).build();
-            }
-            return cp;
-        };
-
-        return await Promise.all(contactPoints.map(fetchAddressMatch));
-    }
-
+    return await Promise.all(contactPoints.map(fetchAddressMatch));
+  }
 }

--- a/migration-scripts/transfer-instances/transfer-instances-script.ts
+++ b/migration-scripts/transfer-instances/transfer-instances-script.ts
@@ -10,6 +10,7 @@ import { DomainToQuadsMapper } from "../../src/driven/persistence/domain-to-quad
 import { FormalInformalChoiceSparqlRepository } from "../../src/driven/persistence/formal-informal-choice-sparql-repository";
 import { TransferInstanceService } from "./transfer-instance-service";
 import { AdressenRegisterFetcher } from "../../src/driven/external/adressen-register-fetcher";
+import { buildFilename } from "./util";
 
 const endPoint = process.env.SPARQL_URL;
 const directDatabaseAccess = new DirectDatabaseAccess(endPoint);
@@ -27,42 +28,125 @@ const transferInstanceService = new TransferInstanceService(
   adressenRegister,
 );
 
-async function main(
+const TARGET_DIRECTORY = "./migration-results";
+
+async function generateMigration(
   fromAuthorityId: Iri,
   toAuthorityId: Iri,
   onlyForMunicipalityMergerInstances: boolean,
+  copyLocalAuthorities: boolean,
 ) {
-  const insertQuads = [];
+  const insertTriples = [];
   const fromAuthority =
     await bestuurseenheidRepository.findById(fromAuthorityId);
   const toAuthority = await bestuurseenheidRepository.findById(toAuthorityId);
-  const domainToQuadsMerger = new DomainToQuadsMapper(toAuthority.userGraph());
 
-  const instanceIds: Iri[] = onlyForMunicipalityMergerInstances
+  const domainToQuadsMerger = new DomainToQuadsMapper(toAuthority.userGraph());
+  let instanceIds: Iri[] = onlyForMunicipalityMergerInstances
     ? await getAllInstanceIdsWithMunicipalityMergerForBestuurseenheid(
         fromAuthority,
       )
     : await getAllInstanceIdsForBestuurseenheid(fromAuthority);
 
-  console.log(`Instances to transfer: ${instanceIds.length}`);
-  for (const instanceId of instanceIds) {
-    const newInstance = await transferInstanceService.transfer(
-      instanceId,
-      fromAuthority,
-      toAuthority,
+  if (instanceIds.length > 0) {
+    console.log(`Instances to transfer: ${instanceIds.length}`);
+
+    for (const instanceId of instanceIds) {
+      const newInstance = await transferInstanceService.transfer(
+        instanceId,
+        fromAuthority,
+        toAuthority,
+        copyLocalAuthorities,
+      );
+
+      const triples = domainToQuadsMerger
+        .instanceToQuads(newInstance)
+        .map((quad) => quad.toNT())
+        .join("\n");
+      insertTriples.push(triples);
+    }
+
+    console.log(
+      `Generating transfer migration from ${fromAuthority.prefLabel} to ${toAuthority.prefLabel}`,
     );
 
-    const quads = domainToQuadsMerger
-      .instanceToQuads(newInstance)
-      .map((quad) => quad.toCanonical())
-      .join("\n");
-    insertQuads.push(quads);
+    const filename = buildFilename(
+      "transfer-instances",
+      fromAuthority.prefLabel,
+      toAuthority.prefLabel + "-" + toAuthority.classificatieCode,
+    );
+
+    fs.writeFileSync(
+      `${TARGET_DIRECTORY}/${filename}.ttl`,
+      insertTriples.join("\n"),
+    );
+
+    fs.writeFileSync(
+      `${TARGET_DIRECTORY}/${filename}.graph`,
+      toAuthority.userGraph().toString(),
+    );
+
+    console.log(`Instances done: ${insertTriples.length}`);
+    console.log(`Wrote transfer migration to ${filename}`);
+
+    // Remove the merger label for all original product instances. Do this for
+    // each source authority, irrelevant whether they want to transfer
+    // everything or a selection. This prevents that any original products with
+    // the merger label remain.
+    instanceIds = onlyForMunicipalityMergerInstances
+      ? instanceIds
+      : await getAllInstanceIdsWithMunicipalityMergerForBestuurseenheid(
+          fromAuthority,
+        );
+    if (instanceIds.length > 0) {
+      // Ensure the merger labels on the original product instances are only
+      // disabled after these instances were transferred.
+      await new Promise((r) => setTimeout(r, 2000));
+      disableMergerLabelForOriginalInstances(instanceIds, fromAuthority);
+    }
+  } else {
+    console.log(`No instances found for ${fromAuthority.prefLabel}`);
   }
-  fs.writeFileSync(
-    `./migration-results/transfer-instances.ttl`,
-    insertQuads.join("\n"),
+}
+
+function disableMergerLabelForOriginalInstances(
+  instanceIds: Iri[],
+  bestuurseenheid: Bestuurseenheid,
+) {
+  const filename = buildFilename(
+    "disable-merger-labels",
+    bestuurseenheid.classificatieCode + "-" + bestuurseenheid.prefLabel,
   );
-  console.log(`Instances done: ${insertQuads.length}`);
+
+  const mergerLabelPredicate =
+    "<https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#forMunicipalityMerger>";
+
+  let deleteTriples = [];
+  let insertTriples = [];
+
+  for (const instanceId of instanceIds) {
+    deleteTriples.push(
+      `${sparqlEscapeUri(instanceId)} ${mergerLabelPredicate} "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .`,
+    );
+    insertTriples.push(
+      `${sparqlEscapeUri(instanceId)} ${mergerLabelPredicate} "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .`,
+    );
+  }
+
+  let query: string = `
+  DELETE DATA {
+    GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {
+      ${deleteTriples.join("\n")}
+    }
+  } INSERT DATA {
+    GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {
+      ${insertTriples.join("\n")}
+    }
+  }
+`;
+
+  fs.writeFileSync(`${TARGET_DIRECTORY}/${filename}.sparql`, query);
+  console.log(`Wrote disable merger label migration to ${filename}`);
 }
 
 async function getAllInstanceIdsForBestuurseenheid(
@@ -70,7 +154,7 @@ async function getAllInstanceIdsForBestuurseenheid(
 ): Promise<Iri[]> {
   const query = `
             ${PREFIX.lpdcExt}
-            SELECT ?id WHERE {
+            SELECT DISTINCT ?id WHERE {
                 GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {
                     ?id a lpdcExt:InstancePublicService .
                 }
@@ -85,7 +169,7 @@ async function getAllInstanceIdsWithMunicipalityMergerForBestuurseenheid(
 ): Promise<Iri[]> {
   const query = `
             ${PREFIX.lpdcExt}
-            SELECT ?id WHERE {
+            SELECT DISTINCT ?id WHERE {
                 GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {
                     ?id a lpdcExt:InstancePublicService .
                     ?id lpdcExt:forMunicipalityMerger """true"""^^<http://www.w3.org/2001/XMLSchema#boolean>
@@ -96,8 +180,208 @@ async function getAllInstanceIdsWithMunicipalityMergerForBestuurseenheid(
   return instanceIds.map((instanceId) => new Iri(instanceId["id"].value));
 }
 
-const fromAuthority = new Iri("");
-const toAuthority = new Iri("");
-const onlyForMunicipalityMergerInstances: boolean = true;
+type Configuration = {
+  fromAuthority: string; // URI of the administrative unit to transfer from
+  toAuthority: string; // URI of the administrative unit to transfer to
+  // Optional boolean to indicate whether only product instances with the merger
+  // label should be transferred.
+  onlyMunicipalityMergerInstances?: boolean;
+};
 
-main(fromAuthority, toAuthority, onlyForMunicipalityMergerInstances);
+// Configurations for 2025 municipality mergers
+const transferConfiguration: Configuration[] = [
+  // Antwerpen -> Antwerpen
+  // Requested to transfer *no* product instances
+  // Borsbeek -> Antwerpen
+  // Requested to transfer *no* product instances
+
+  // Beveren -> Beveren-Kruibeke-Zwijndrecht
+  // Requested to transfer *no* product instances
+  // Kruibeke -> Beveren-Kruibeke-Zwijndrecht
+  // Requested to transfer *no* product instances
+  // Zwijndrecht -> Beveren-Kruibeke-Zwijndrecht
+  // Requested to transfer *selected* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/c362abc58ac4579ff417824ce620962ac57bc344b34fe8f51d21b35ef54da36d",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/19483103-318e-435a-aa37-45e485406ee9",
+    onlyMunicipalityMergerInstances: true,
+  },
+
+  // Bilzen -> Bilzen
+  // Requested to transfer *all* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/99da98a7a0087d3429b084ebfc4eb5d488c593790d4d5af7253982a2e21a6a5f",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/99da98a7a0087d3429b084ebfc4eb5d488c593790d4d5af7253982a2e21a6a5f",
+  },
+  // Hoeselt -> Bilzen
+  // Requested to transfer *no* product instances
+
+  // Borgloon -> Tongeren
+  // Requested to transfer *all* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625",
+  },
+  // Tongeren -> Tongeren
+  // Requested to transfer *all* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625",
+  },
+
+  // De Pinte -> Nazareth-De Pinte
+  // Requested to transfer *no* product instances
+  // Nazareth -> Nazareth-De Pinte
+  // Requested to transfer *selected* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/0327a51548f73607f8a5ec11b36711a3c96703686ad93a3d632718c135c295db",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/1ca65d65-54ff-4b44-b750-bd70c91191af",
+    onlyMunicipalityMergerInstances: true,
+  },
+
+  // Galmaarden -> Pajottegem
+  // Requested to transfer *no* product instances
+  // Gooik -> Pajottegem
+  // Requested to transfer *no* product instances
+  // Herne -> Pajottegem
+  // Requested to transfer *no* product instances
+
+  // Ham -> Tessenderlo-Ham
+  // Requested to transfer *no* product instances
+  // Tessenderlo -> Tessenderlo-Ham
+  // Requested to transfer *no* product instances
+
+  // Kortessem -> Hasselt
+  // Requested to transfer *no* product instances
+  // Hasselt -> Hasselt
+  // Requested to transfer *all* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169",
+  },
+  // Hasselt (OCMW) -> Hasselt (OCMW)
+  // Requested to transfer *all* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/026509cf3b4eeb7ad88fe57a270060574f60abd1c3524837d36700e40809d210",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/026509cf3b4eeb7ad88fe57a270060574f60abd1c3524837d36700e40809d210",
+  },
+
+  // Lochristi -> Lochristi
+  // Requested to transfer *selected* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/2ac1bb2a7d7bbd98e2e7a24be2c67e42171788a71c2436a33060626593bb2f78",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/2ac1bb2a7d7bbd98e2e7a24be2c67e42171788a71c2436a33060626593bb2f78",
+    onlyMunicipalityMergerInstances: true,
+  },
+  // Wachtebeke -> Lochristi
+  // Requested to transfer *selected* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/1313d4a58f9ecf52cc7e274e3549a759b35e731973cc9f5e07562e5650f594dd",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/2ac1bb2a7d7bbd98e2e7a24be2c67e42171788a71c2436a33060626593bb2f78",
+    onlyMunicipalityMergerInstances: true,
+  },
+
+  // Lokeren -> Lokeren
+  // Requested to transfer *all* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/cb2a6e0a490ee881ddd0d9ded7f2b3d1dc2df7e57a19d014caac054bfa355f5a",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/cb2a6e0a490ee881ddd0d9ded7f2b3d1dc2df7e57a19d014caac054bfa355f5a",
+  },
+  // Lokeren (OCMW) -> Lokeren (OCMW)
+  // Requested to transfer *all* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/323a24f2fe81ee0b6586ec78be36760e478092e07386b2785992ea8b61941833",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/323a24f2fe81ee0b6586ec78be36760e478092e07386b2785992ea8b61941833",
+  },
+  // Moerbeke -> Lokeren
+  // Requested to transfer *no* product instances
+
+  // Melle -> Merelbeke-Melle
+  // Requested to transfer *no* product instances
+  // Merelbeke -> Merelbeke-Melle
+  // Requested to transfer *selected* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/8ef1e4a43efd913e6b09b0ddea344b7b5d723a344ad559389a55ae1ff0bebc8f",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/b8bb293d-aa22-4b43-bda4-0b6af76e9493",
+    onlyMunicipalityMergerInstances: true,
+  },
+
+  // Meulebeke -> Tielt
+  // Requested to transfer *all* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a",
+  },
+  // Tielt -> Tielt
+  // Requested to transfer *all* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a",
+  },
+
+  // Ruiselede -> Wingene
+  // Requested to transfer *selected* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/2564e21e3650f91625189ccb7eb055e47754a0633c54c7582a899171fef60c52",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/99ed6eee81a7aca47517cbffb46eaba38f3987eeb4ad32c020898644769eb615",
+    onlyMunicipalityMergerInstances: true,
+  },
+  // Wingene -> Wingene
+  // Requested to transfer *selected* product instances
+  {
+    fromAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/99ed6eee81a7aca47517cbffb46eaba38f3987eeb4ad32c020898644769eb615",
+    toAuthority:
+      "http://data.lblod.info/id/bestuurseenheden/99ed6eee81a7aca47517cbffb46eaba38f3987eeb4ad32c020898644769eb615",
+    onlyMunicipalityMergerInstances: true,
+  },
+];
+
+// const transferConfiguration: Configuration[] = [
+//   {
+//     fromAuthority: "",
+//     toAuthority: "",
+//     onlyMunicipalityMergerInstances: true,
+//   },
+// ];
+
+for (const conf of transferConfiguration) {
+  generateMigration(
+    new Iri(conf.fromAuthority),
+    new Iri(conf.toAuthority),
+    conf.onlyMunicipalityMergerInstances
+      ? conf.onlyMunicipalityMergerInstances
+      : false,
+    true, // Update local authorities using migration later
+  );
+}

--- a/migration-scripts/transfer-instances/transfer-instances-script.ts
+++ b/migration-scripts/transfer-instances/transfer-instances-script.ts
@@ -1,48 +1,74 @@
-import {DirectDatabaseAccess} from "../../test/driven/persistence/direct-database-access";
-import {PREFIX} from "../../config";
-import {sparqlEscapeUri} from "../../mu-helper";
-import {Bestuurseenheid} from "../../src/core/domain/bestuurseenheid";
-import {Iri} from "../../src/core/domain/shared/iri";
-import {InstanceSparqlRepository} from "../../src/driven/persistence/instance-sparql-repository";
+import { DirectDatabaseAccess } from "../../test/driven/persistence/direct-database-access";
+import { PREFIX } from "../../config";
+import { sparqlEscapeUri } from "../../mu-helper";
+import { Bestuurseenheid } from "../../src/core/domain/bestuurseenheid";
+import { Iri } from "../../src/core/domain/shared/iri";
+import { InstanceSparqlRepository } from "../../src/driven/persistence/instance-sparql-repository";
 import fs from "fs";
-import {BestuurseenheidSparqlRepository} from "../../src/driven/persistence/bestuurseenheid-sparql-repository";
-import {DomainToQuadsMapper} from "../../src/driven/persistence/domain-to-quads-mapper";
-import {
-    FormalInformalChoiceSparqlRepository
-} from "../../src/driven/persistence/formal-informal-choice-sparql-repository";
-import {TransferInstanceService} from "./transfer-instance-service";
-import {AdressenRegisterFetcher} from "../../src/driven/external/adressen-register-fetcher";
+import { BestuurseenheidSparqlRepository } from "../../src/driven/persistence/bestuurseenheid-sparql-repository";
+import { DomainToQuadsMapper } from "../../src/driven/persistence/domain-to-quads-mapper";
+import { FormalInformalChoiceSparqlRepository } from "../../src/driven/persistence/formal-informal-choice-sparql-repository";
+import { TransferInstanceService } from "./transfer-instance-service";
+import { AdressenRegisterFetcher } from "../../src/driven/external/adressen-register-fetcher";
 
 const endPoint = process.env.SPARQL_URL;
 const directDatabaseAccess = new DirectDatabaseAccess(endPoint);
 const bestuurseenheidRepository = new BestuurseenheidSparqlRepository(endPoint);
 const instanceRepository = new InstanceSparqlRepository(endPoint);
-const formalInformalChoiceRepository = new FormalInformalChoiceSparqlRepository(endPoint);
+const formalInformalChoiceRepository = new FormalInformalChoiceSparqlRepository(
+  endPoint,
+);
 const adressenRegister = new AdressenRegisterFetcher();
 
-const transferInstanceService = new TransferInstanceService(bestuurseenheidRepository, instanceRepository, formalInformalChoiceRepository, adressenRegister);
+const transferInstanceService = new TransferInstanceService(
+  bestuurseenheidRepository,
+  instanceRepository,
+  formalInformalChoiceRepository,
+  adressenRegister,
+);
 
-async function main(fromAuthorityId: Iri, toAuthorityId: Iri, onlyForMunicipalityMergerInstances: boolean) {
-    const insertQuads = [];
-    const fromAuthority = await bestuurseenheidRepository.findById(fromAuthorityId);
-    const toAuthority = await bestuurseenheidRepository.findById(toAuthorityId);
-    const domainToQuadsMerger = new DomainToQuadsMapper(toAuthority.userGraph());
+async function main(
+  fromAuthorityId: Iri,
+  toAuthorityId: Iri,
+  onlyForMunicipalityMergerInstances: boolean,
+) {
+  const insertQuads = [];
+  const fromAuthority =
+    await bestuurseenheidRepository.findById(fromAuthorityId);
+  const toAuthority = await bestuurseenheidRepository.findById(toAuthorityId);
+  const domainToQuadsMerger = new DomainToQuadsMapper(toAuthority.userGraph());
 
-    const instanceIds: Iri[] = onlyForMunicipalityMergerInstances ? await getAllInstanceIdsWithMunicipalityMergerForBestuurseenheid(fromAuthority) : await getAllInstanceIdsForBestuurseenheid(fromAuthority);
+  const instanceIds: Iri[] = onlyForMunicipalityMergerInstances
+    ? await getAllInstanceIdsWithMunicipalityMergerForBestuurseenheid(
+        fromAuthority,
+      )
+    : await getAllInstanceIdsForBestuurseenheid(fromAuthority);
 
-    console.log(`Instances to transfer: ${instanceIds.length}`);
-    for (const instanceId of instanceIds) {
-        const newInstance = await transferInstanceService.transfer(instanceId, fromAuthority, toAuthority);
-        
-        const quads = domainToQuadsMerger.instanceToQuads(newInstance).map(quad => quad.toCanonical()).join('\n');
-        insertQuads.push(quads);
-    }
-    fs.writeFileSync(`./migration-results/transfer-instances.ttl`, insertQuads.join('\n'));
-    console.log("instances done " + insertQuads.length);
+  console.log(`Instances to transfer: ${instanceIds.length}`);
+  for (const instanceId of instanceIds) {
+    const newInstance = await transferInstanceService.transfer(
+      instanceId,
+      fromAuthority,
+      toAuthority,
+    );
+
+    const quads = domainToQuadsMerger
+      .instanceToQuads(newInstance)
+      .map((quad) => quad.toCanonical())
+      .join("\n");
+    insertQuads.push(quads);
+  }
+  fs.writeFileSync(
+    `./migration-results/transfer-instances.ttl`,
+    insertQuads.join("\n"),
+  );
+  console.log(`Instances done: ${insertQuads.length}`);
 }
 
-async function getAllInstanceIdsForBestuurseenheid(bestuurseenheid: Bestuurseenheid): Promise<Iri[]> {
-    const query = `
+async function getAllInstanceIdsForBestuurseenheid(
+  bestuurseenheid: Bestuurseenheid,
+): Promise<Iri[]> {
+  const query = `
             ${PREFIX.lpdcExt}
             SELECT ?id WHERE {
                 GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {
@@ -50,12 +76,14 @@ async function getAllInstanceIdsForBestuurseenheid(bestuurseenheid: Bestuurseenh
                 }
             }
             `;
-    const instanceIds = await directDatabaseAccess.list(query);
-    return instanceIds.map(instanceId => new Iri(instanceId['id'].value));
+  const instanceIds = await directDatabaseAccess.list(query);
+  return instanceIds.map((instanceId) => new Iri(instanceId["id"].value));
 }
 
-async function getAllInstanceIdsWithMunicipalityMergerForBestuurseenheid(bestuurseenheid: Bestuurseenheid): Promise<Iri[]> {
-    const query = `
+async function getAllInstanceIdsWithMunicipalityMergerForBestuurseenheid(
+  bestuurseenheid: Bestuurseenheid,
+): Promise<Iri[]> {
+  const query = `
             ${PREFIX.lpdcExt}
             SELECT ?id WHERE {
                 GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {
@@ -64,13 +92,12 @@ async function getAllInstanceIdsWithMunicipalityMergerForBestuurseenheid(bestuur
                 }
             }
             `;
-    const instanceIds = await directDatabaseAccess.list(query);
-    return instanceIds.map(instanceId => new Iri(instanceId['id'].value));
+  const instanceIds = await directDatabaseAccess.list(query);
+  return instanceIds.map((instanceId) => new Iri(instanceId["id"].value));
 }
 
 const fromAuthority = new Iri("");
 const toAuthority = new Iri("");
-const onlyForMunicipalityMergerInstances: boolean = false;
-
+const onlyForMunicipalityMergerInstances: boolean = true;
 
 main(fromAuthority, toAuthority, onlyForMunicipalityMergerInstances);

--- a/migration-scripts/transfer-instances/util.ts
+++ b/migration-scripts/transfer-instances/util.ts
@@ -1,0 +1,24 @@
+export function buildFilename(
+  infix: string,
+  fromLabel: string,
+  toLabel?: string,
+): string {
+  const timestamp = generateFilenamePrefix();
+  const from = "from-" + normalizeLabel(fromLabel);
+  const to = toLabel ? "-to-" + normalizeLabel(toLabel) : "";
+
+  return `${timestamp}-${infix}-${from}${to}`;
+}
+
+function normalizeLabel(label: string) {
+  return label.replaceAll(" ", "_").toLocaleLowerCase();
+}
+
+function generateFilenamePrefix(): string {
+  let date = new Date();
+  return `${date.getFullYear()}${addLeadingZero(date.getMonth() + 1)}${addLeadingZero(date.getDate())}${addLeadingZero(date.getHours())}${addLeadingZero(date.getMinutes())}${addLeadingZero(date.getSeconds())}`;
+}
+
+function addLeadingZero(num: number): string {
+  return num < 10 ? `0${num}` : `${num}`;
+}


### PR DESCRIPTION
This management service contains two scripts that simplify handling municipality mergers. These scripts generate migrations to
- copy product instances between two organisations; and
- archive product instances from an organisation.

The bulk of these scripts was prepared the previous team. This PR extends their work to fully cover all scenarios for the 2025 municipality mergers.

## Usage
See the [README](https://github.com/lblod/lpdc-management-service/blob/feat/extend-instance-transfer-scripts/migration-scripts/transfer-instances/readme.md) on how to use the scripts.

Notes:
- the `archive-instances-script` will only be used some time in the future when the merged municipalities can be removed altogether, somewhere after 01/01/2025.
- the `transfer-instances-script` does **not** update the NUTS codes linked to the product instances via `dcterms:spatial`, this is the "Geografisch toepassingsgebied" field in the frontend. These values will have to be updated by an additional migration. It is important that this migration is executed **after** those generated by the `transfer-instances-script` as it will have no effect otherwise. An example of that migration can be found in [PR40](https://github.com/lblod/app-lpdc-digitaal-loket/pull/40).

## Changes
### Transfer instances
- feat: specify multiple organisation pairs to transfer product instances instead of having to run the script separately for each pair
- feat: set target organisation as local competent and executing authority of transferred product instances
- fix: avoid generating empty migrations
- fix: enable merger label on transferred product instances and disable it on any original products
- chore: simply copy contact points when transferring a product instance instead of trying it to update it via address registry. The address registry will only update for the mergers as of mid December 2024.
- refactor: formatting

### Archive instances
- feat: allow specify multiple organisations for which to archive their products
- feat: allow to archive only product instances without the merger label
- refactor: formatting

## Notes
- An example of the migrations generated by the `transfer-instances-script` can be found in [PR40](https://github.com/lblod/app-lpdc-digitaal-loket/pull/40).
- The first commit in PR only contains formatting changes, all functional changes are contained in later commits.

## Related tickets
- LPDC-1315
- LPDC-1316