### PR TITLE
feat: do not allow publishing a product instance linked to old municipalities

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -130,6 +130,7 @@ const validateInstanceForPublishApplicationService =
   new ValidateInstanceForPublishApplicationService(
     formApplicationService,
     instanceRepository,
+    bestuurseenheidRepository,
   );
 
 const linkConceptToInstanceDomainService =

--- a/app.ts
+++ b/app.ts
@@ -51,6 +51,7 @@ import { VersionedLdesSnapshotSparqlRepository } from "./src/driven/persistence/
 import { AdressenRegisterFetcher } from "./src/driven/external/adressen-register-fetcher";
 import { ContactInfoOptionsSparqlRepository } from "./src/driven/persistence/contact-info-options-sparql-repository";
 import { ConceptSnapshotProcessorApplicationService } from "./src/core/application/concept-snapshot-processor-application-service";
+import { SpatialSparqlRepository } from "./src/driven/persistence/spatial-sparql-repository";
 
 //TODO: The original bodyparser is configured to only accept 'application/vnd.api+json'
 //      The current endpoint(s) don't work with json:api. Also we need both types, as e.g. deltanotifier doesn't
@@ -79,6 +80,7 @@ const instanceSnapshotProcessingAuthorizationRepository =
   new InstanceSnapshotProcessingAuthorizationSparqlRepository();
 const versionedLdesSnapshotRepository =
   new VersionedLdesSnapshotSparqlRepository();
+const spatialRepository = new SpatialSparqlRepository();
 
 const linkedAuthorityCodeListDomainService =
   new EnsureLinkedAuthoritiesExistAsCodeListDomainService(
@@ -131,6 +133,7 @@ const validateInstanceForPublishApplicationService =
     formApplicationService,
     instanceRepository,
     bestuurseenheidRepository,
+    spatialRepository,
   );
 
 const linkConceptToInstanceDomainService =

--- a/config.ts
+++ b/config.ts
@@ -62,6 +62,7 @@ const PREFIX = {
   ex: "PREFIX ex: <http://example.com/ns#>",
   nutss: "PREFIX nutss: <http://data.europa.eu/nuts/scheme/>",
   prov: "PREFIX prov: <http://www.w3.org/ns/prov#>",
+  regorg: "PREFIX regorg: <http://www.w3.org/ns/regorg#>",
 };
 
 export {

--- a/config.ts
+++ b/config.ts
@@ -61,8 +61,10 @@ const PREFIX = {
   sh: "PREFIX sh: <http://www.w3.org/ns/shacl#>",
   ex: "PREFIX ex: <http://example.com/ns#>",
   nutss: "PREFIX nutss: <http://data.europa.eu/nuts/scheme/>",
+  nuts: "PREFIX nuts: <http://data.europa.eu/nuts/code/>",
   prov: "PREFIX prov: <http://www.w3.org/ns/prov#>",
   regorg: "PREFIX regorg: <http://www.w3.org/ns/regorg#>",
+  time: "PREFIX time: <http://www.w3.org/2006/time#>",
 };
 
 export {

--- a/config.ts
+++ b/config.ts
@@ -24,6 +24,8 @@ const CONCEPT_SNAPSHOT_PROCESSING_CRON_PATTERN =
 const IPDC_API_ENDPOINT = process.env.IPDC_API_ENDPOINT;
 const IPDC_API_KEY = process.env.IPDC_API_KEY;
 
+const NUTS_VERSION = "http://data.europa.eu/nuts/scheme/2024";
+
 const PREFIX = {
   rdf: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
   skos: "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>",
@@ -81,4 +83,5 @@ export {
   INSTANCE_SNAPSHOT_PROCESSING_CRON_PATTERN,
   IPDC_API_ENDPOINT,
   IPDC_API_KEY,
+  NUTS_VERSION,
 };

--- a/src/core/application/validate-instance-for-publish-application-service.ts
+++ b/src/core/application/validate-instance-for-publish-application-service.ts
@@ -9,23 +9,29 @@ import { InvariantError, NotFoundError } from "../domain/shared/lpdc-error";
 import { Instance } from "../domain/instance";
 import { ENABLE_ADDRESS_VALIDATION } from "../../../config";
 import { BestuurseenheidRepository } from "../port/driven/persistence/bestuurseenheid-repository";
+import { SpatialRepository } from "../port/driven/persistence/spatial-repository";
 
 export const INACTIVE_AUTHORITY_ERROR_MESSAGE =
   "Het product dat je probeert te verzenden, is gelinkt aan een inactief bestuur. Kijk in de tab ‘eigenschappen’ de overheidsorganisatie na.";
+export const EXPIRED_SPATIAL_ERROR_MESSAGE =
+  "Het product dat je probeert te verzenden, is gelinkt aan een inactief bestuur. Kijk in de tab ‘eigenschappen’ het geografisch toepassingsgebied na.";
 
 export class ValidateInstanceForPublishApplicationService {
   private readonly _formApplicationService: FormApplicationService;
   private readonly _instanceRepository: InstanceRepository;
   private readonly _bestuurseenheidRepository: BestuurseenheidRepository;
+  private readonly _spatialRepository: SpatialRepository;
 
   constructor(
     formApplicationService: FormApplicationService,
     instanceRepository: InstanceRepository,
     bestuurseenheidRepository: BestuurseenheidRepository,
+    spatialRepository: SpatialRepository,
   ) {
     this._formApplicationService = formApplicationService;
     this._instanceRepository = instanceRepository;
     this._bestuurseenheidRepository = bestuurseenheidRepository;
+    this._spatialRepository = spatialRepository;
   }
 
   async validate(
@@ -36,42 +42,79 @@ export class ValidateInstanceForPublishApplicationService {
       instanceId,
       bestuurseenheid,
     );
+
     if (errorList.length) {
       return errorList;
-    } else {
-      const instance = await this._instanceRepository.findById(
-        bestuurseenheid,
-        instanceId,
+    }
+
+    const instance = await this._instanceRepository.findById(
+      bestuurseenheid,
+      instanceId,
+    );
+
+    const authorityError = await this.validateAuthorities(instance);
+    if (authorityError) {
+      errorList.push(authorityError);
+    }
+
+    const spatialError = await this.validateSpatials(instance);
+    if (spatialError) {
+      errorList.push(spatialError);
+    }
+
+    if (errorList.length) {
+      return errorList;
+    }
+
+    return this.tryValidateForPublish(instance);
+  }
+
+  private async validateAuthorities(
+    instance: Instance,
+  ): Promise<ValidationError> {
+    try {
+      const competentAuthorities = await Promise.all(
+        instance.competentAuthorities.flatMap(
+          async (uri) => await this._bestuurseenheidRepository.findById(uri),
+        ),
       );
 
-      // TODO: refactor to clean up code and avoid duplication
-      try {
-        const competentAuthorities = await Promise.all(
-          instance.competentAuthorities.flatMap(
-            async (uri) => await this._bestuurseenheidRepository.findById(uri),
-          ),
-        );
+      const executingAuthorities = await Promise.all(
+        instance.executingAuthorities.flatMap(
+          async (uri) => await this._bestuurseenheidRepository.findById(uri),
+        ),
+      );
 
-        const executingAuthorities = await Promise.all(
-          instance.executingAuthorities.flatMap(
-            async (uri) => await this._bestuurseenheidRepository.findById(uri),
-          ),
-        );
+      const hasInvalidAuthority = competentAuthorities
+        .concat(executingAuthorities)
+        .some((authority) => !authority.isValidAuthority);
 
-        const hasInvalidAuthority = competentAuthorities
-          .concat(executingAuthorities)
-          .some((authority) => !authority.isValidAuthority);
-
-        if (hasInvalidAuthority) {
-          return [{ message: INACTIVE_AUTHORITY_ERROR_MESSAGE }];
-        }
-      } catch (e) {
-        if (e instanceof NotFoundError) {
-          return [{ message: INACTIVE_AUTHORITY_ERROR_MESSAGE }];
-        }
+      if (hasInvalidAuthority) {
+        return { message: INACTIVE_AUTHORITY_ERROR_MESSAGE };
       }
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        return { message: INACTIVE_AUTHORITY_ERROR_MESSAGE };
+      }
+    }
+  }
 
-      return this.tryValidateForPublish(instance);
+  private async validateSpatials(instance: Instance): Promise<ValidationError> {
+    try {
+      const spatials = await Promise.all(
+        instance.spatials.flatMap((uri) =>
+          this._spatialRepository.findById(uri),
+        ),
+      );
+
+      const hasExpiredSpatial = spatials.some((spatial) => spatial.isExpired);
+      if (hasExpiredSpatial) {
+        return { message: EXPIRED_SPATIAL_ERROR_MESSAGE };
+      }
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        return { message: EXPIRED_SPATIAL_ERROR_MESSAGE };
+      }
     }
   }
 

--- a/src/core/application/validate-instance-for-publish-application-service.ts
+++ b/src/core/application/validate-instance-for-publish-application-service.ts
@@ -5,20 +5,27 @@ import {
 import { Iri } from "../domain/shared/iri";
 import { Bestuurseenheid } from "../domain/bestuurseenheid";
 import { InstanceRepository } from "../port/driven/persistence/instance-repository";
-import { InvariantError } from "../domain/shared/lpdc-error";
+import { InvariantError, NotFoundError } from "../domain/shared/lpdc-error";
 import { Instance } from "../domain/instance";
 import { ENABLE_ADDRESS_VALIDATION } from "../../../config";
+import { BestuurseenheidRepository } from "../port/driven/persistence/bestuurseenheid-repository";
+
+export const INACTIVE_AUTHORITY_ERROR_MESSAGE =
+  "Het product dat je probeert te verzenden, is gelinkt aan een inactief bestuur. Kijk in de tab ‘eigenschappen’ de overheidsorganisatie na.";
 
 export class ValidateInstanceForPublishApplicationService {
   private readonly _formApplicationService: FormApplicationService;
   private readonly _instanceRepository: InstanceRepository;
+  private readonly _bestuurseenheidRepository: BestuurseenheidRepository;
 
   constructor(
     formApplicationService: FormApplicationService,
     instanceRepository: InstanceRepository,
+    bestuurseenheidRepository: BestuurseenheidRepository,
   ) {
     this._formApplicationService = formApplicationService;
     this._instanceRepository = instanceRepository;
+    this._bestuurseenheidRepository = bestuurseenheidRepository;
   }
 
   async validate(
@@ -36,6 +43,34 @@ export class ValidateInstanceForPublishApplicationService {
         bestuurseenheid,
         instanceId,
       );
+
+      // TODO: refactor to clean up code and avoid duplication
+      try {
+        const competentAuthorities = await Promise.all(
+          instance.competentAuthorities.flatMap(
+            async (uri) => await this._bestuurseenheidRepository.findById(uri),
+          ),
+        );
+
+        const executingAuthorities = await Promise.all(
+          instance.executingAuthorities.flatMap(
+            async (uri) => await this._bestuurseenheidRepository.findById(uri),
+          ),
+        );
+
+        const hasInvalidAuthority = competentAuthorities
+          .concat(executingAuthorities)
+          .some((authority) => !authority.isValidAuthority);
+
+        if (hasInvalidAuthority) {
+          return [{ message: INACTIVE_AUTHORITY_ERROR_MESSAGE }];
+        }
+      } catch (e) {
+        if (e instanceof NotFoundError) {
+          return [{ message: INACTIVE_AUTHORITY_ERROR_MESSAGE }];
+        }
+      }
+
       return this.tryValidateForPublish(instance);
     }
   }

--- a/src/core/domain/bestuurseenheid.ts
+++ b/src/core/domain/bestuurseenheid.ts
@@ -14,6 +14,7 @@ export class Bestuurseenheid {
   private readonly _classificatieCode:
     | BestuurseenheidClassificatieCode
     | undefined;
+  private readonly _status: BestuurseenheidStatusCode | undefined;
   private readonly _spatials: Iri[];
 
   constructor(
@@ -21,6 +22,7 @@ export class Bestuurseenheid {
     uuid: string,
     prefLabel: string,
     classificatieCode: BestuurseenheidClassificatieCode | undefined,
+    status: BestuurseenheidStatusCode | undefined,
     spatials: Iri[],
   ) {
     this._id = requiredValue(id, "id");
@@ -29,6 +31,7 @@ export class Bestuurseenheid {
     this._classificatieCode = id.equals(Bestuurseenheid.abb)
       ? classificatieCode
       : requiredValue(classificatieCode, "classificatieCode");
+    this._status = status;
     this._spatials = requireNoDuplicates(
       asSortedArray(spatials, Iri.compare),
       "spatials",
@@ -49,6 +52,10 @@ export class Bestuurseenheid {
 
   get classificatieCode(): BestuurseenheidClassificatieCode | undefined {
     return this._classificatieCode;
+  }
+
+  get status(): BestuurseenheidStatusCode | undefined {
+    return this._status;
   }
 
   get spatials(): Iri[] {
@@ -83,4 +90,10 @@ export enum BestuurseenheidClassificatieCode {
   WELZIJNSVERENIGING = "Welzijnsvereniging",
   OCMW_VERENIGING = "OCMW vereniging",
   VLAAMSE_GEMEENSCHAPSCOMMISSIE = "Vlaamse gemeenschapscommissie",
+}
+
+export enum BestuurseenheidStatusCode {
+  ACTIVE = "Actief",
+  INACTIVE = "Niet actief",
+  IN_FORMATION = "In oprichting",
 }

--- a/src/core/domain/bestuurseenheid.ts
+++ b/src/core/domain/bestuurseenheid.ts
@@ -67,6 +67,13 @@ export class Bestuurseenheid {
       `http://mu.semte.ch/graphs/organizations/${this.uuid}/${SessionRoleType.LOKETLB_LPDCGEBRUIKER}`,
     );
   }
+
+  get isValidAuthority(): boolean {
+    return (
+      this._status === BestuurseenheidStatusCode.ACTIVE ||
+      this._status === BestuurseenheidStatusCode.IN_FORMATION
+    );
+  }
 }
 
 export enum BestuurseenheidClassificatieCode {

--- a/src/core/domain/spatial.ts
+++ b/src/core/domain/spatial.ts
@@ -1,0 +1,48 @@
+import { requiredValue } from "./shared/invariant";
+import { Iri } from "./shared/iri";
+
+export class Spatial {
+  private readonly _id: Iri;
+  private readonly _uuid: string;
+  private readonly _prefLabel: string;
+  private readonly _notation: string;
+  private readonly _endDate: Date | undefined;
+
+  constructor(
+    id: Iri,
+    uuid: string,
+    prefLabel: string,
+    notation: string,
+    endDate?: Date | undefined,
+  ) {
+    this._id = requiredValue(id, "id");
+    this._uuid = requiredValue(uuid, "uuid");
+    this._prefLabel = requiredValue(prefLabel, "prefLabel");
+    this._notation = requiredValue(notation, "notation");
+    this._endDate = endDate;
+  }
+
+  get id(): Iri {
+    return this._id;
+  }
+
+  get uuid(): string {
+    return this._uuid;
+  }
+
+  get prefLabel(): string {
+    return this._prefLabel;
+  }
+
+  get notation(): string {
+    return this._notation;
+  }
+
+  get endDate(): Date {
+    return this._endDate;
+  }
+
+  get isExpired(): boolean {
+    return this.endDate && this.endDate < new Date();
+  }
+}

--- a/src/core/port/driven/persistence/spatial-repository.ts
+++ b/src/core/port/driven/persistence/spatial-repository.ts
@@ -1,0 +1,6 @@
+import { Iri } from "../../../domain/shared/iri";
+import { Spatial } from "../../../domain/spatial";
+
+export interface SpatialRepository {
+  findById(id: Iri): Promise<Spatial>;
+}

--- a/src/driven/persistence/bestuurseenheid-sparql-repository.ts
+++ b/src/driven/persistence/bestuurseenheid-sparql-repository.ts
@@ -3,6 +3,7 @@ import { Iri } from "../../core/domain/shared/iri";
 import {
   Bestuurseenheid,
   BestuurseenheidClassificatieCode,
+  BestuurseenheidStatusCode,
 } from "../../core/domain/bestuurseenheid";
 import { sparqlEscapeUri } from "../../../mu-helper";
 import { SparqlQuerying } from "./sparql-querying";
@@ -24,7 +25,9 @@ export class BestuurseenheidSparqlRepository
             ${PREFIX.skos}
             ${PREFIX.besluit}
             ${PREFIX.mu}
-            SELECT ?id ?uuid ?prefLabel ?classificatieUri WHERE {
+            ${PREFIX.regorg}
+            SELECT ?id ?uuid ?prefLabel ?classificatieUri ?statusUri
+            WHERE {
                 GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {
                     VALUES ?id {
                         ${sparqlEscapeUri(id)}
@@ -34,7 +37,10 @@ export class BestuurseenheidSparqlRepository
                     ?id skos:prefLabel ?prefLabel .
                     OPTIONAL {
                         ?id besluit:classificatie ?classificatieUri .
-                    } 
+                    }
+                    OPTIONAL {
+                        ?id regorg:orgStatus ?statusUri .
+                    }
                 }
             }
         `;
@@ -48,7 +54,7 @@ export class BestuurseenheidSparqlRepository
                   ?werkingsgebiedId skos:exactMatch ?spatialId.
                   ?spatialId skos:inScheme nutss:2024
                 }
-            }        
+            }
         `;
 
     const [bestuurseenheidQueryResult, resultSpatials] =
@@ -68,6 +74,7 @@ export class BestuurseenheidSparqlRepository
       this.mapBestuurseenheidClassificatieUriToCode(
         bestuurseenheidQueryResult["classificatieUri"]?.value,
       ),
+      this.mapStatusUriToCode(bestuurseenheidQueryResult["statusUri"]?.value),
       (resultSpatials as Promise<unknown>[]).map(
         (r) => new Iri(r["spatialId"].value),
       ),
@@ -97,6 +104,25 @@ export class BestuurseenheidSparqlRepository
     }
     return classificatieCode;
   }
+
+  mapStatusUriToCode(
+    statusUri: BestuurseenheidStatusCodeUri | undefined,
+  ): BestuurseenheidStatusCode {
+    if (!statusUri) {
+      return undefined;
+    }
+
+    const key: string | undefined = Object.keys(
+      BestuurseenheidStatusCodeUri,
+    ).find((key) => BestuurseenheidStatusCodeUri[key] === statusUri);
+
+    const statusCode = BestuurseenheidStatusCode[key];
+    if (!statusCode) {
+      throw new NotFoundError(`Geen statuscode gevonden voor: ${statusUri}`);
+    }
+
+    return statusCode;
+  }
 }
 
 export enum BestuurseenheidClassificatieCodeUri {
@@ -120,4 +146,10 @@ export enum BestuurseenheidClassificatieCodeUri {
   WELZIJNSVERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9",
   OCMW_VERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089",
   VLAAMSE_GEMEENSCHAPSCOMMISSIE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c",
+}
+
+export enum BestuurseenheidStatusCodeUri {
+  ACTIVE = "http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6",
+  INACTIVE = "http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311",
+  IN_FORMATION = "http://lblod.data.gift/concepts/abf4fee82019f88cf122f986830621ab",
 }

--- a/src/driven/persistence/bestuurseenheid-sparql-repository.ts
+++ b/src/driven/persistence/bestuurseenheid-sparql-repository.ts
@@ -7,7 +7,7 @@ import {
 } from "../../core/domain/bestuurseenheid";
 import { sparqlEscapeUri } from "../../../mu-helper";
 import { SparqlQuerying } from "./sparql-querying";
-import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { NUTS_VERSION, PREFIX, PUBLIC_GRAPH } from "../../../config";
 import { extractResultsFromAllSettled } from "../../../platform/promises";
 import { NotFoundError } from "../../core/domain/shared/lpdc-error";
 
@@ -47,12 +47,11 @@ export class BestuurseenheidSparqlRepository
     const spatialsQuery = `
             ${PREFIX.besluit}
             ${PREFIX.skos}
-            ${PREFIX.nutss}
             SELECT DISTINCT ?spatialId WHERE {
                 GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {
                   ${sparqlEscapeUri(id)} besluit:werkingsgebied ?werkingsgebiedId.
                   ?werkingsgebiedId skos:exactMatch ?spatialId.
-                  ?spatialId skos:inScheme nutss:2024
+                  ?spatialId skos:inScheme ${sparqlEscapeUri(NUTS_VERSION)}.
                 }
             }
         `;

--- a/src/driven/persistence/form-definition-file-repository.ts
+++ b/src/driven/persistence/form-definition-file-repository.ts
@@ -2,11 +2,13 @@ import { FormDefinitionRepository } from "../../core/port/driven/persistence/for
 import fs from "fs";
 import { FormType } from "../../core/domain/types";
 import { Language } from "../../core/domain/language";
+import { NUTS_VERSION } from "../../../config";
 
 export class FormDefinitionFileRepository implements FormDefinitionRepository {
   contactpoint = "CONTACTPOINT";
   municipalityMerger = "MUNICIPALITY_MERGER_FILTER";
   language = "FORMAL_INFORMAL_LANGUAGE";
+  nuts_version = "NUTS_VERSION";
 
   public loadInstanceFormDefinition(
     formType: FormType,
@@ -24,6 +26,7 @@ export class FormDefinitionFileRepository implements FormDefinitionRepository {
       "form:includes ext:forMunicipalityMergerF.",
     );
     form = this.replaceInForm(form, this.language, language);
+    form = this.replaceInForm(form, this.nuts_version, NUTS_VERSION);
     return form;
   }
 

--- a/src/driven/persistence/forms/eigenschappen/form.ttl
+++ b/src/driven/persistence/forms/eigenschappen/form.ttl
@@ -225,7 +225,7 @@ ext:authorityPg a form:PropertyGroup;
       sh:path dct:spatial ;
       form:options  """
                      {
-                       "conceptScheme":"http://data.europa.eu/nuts/scheme/2024",
+                       "conceptScheme":"<NUTS_VERSION>",
                        "multiple": true
                      }
                     """ ;

--- a/src/driven/persistence/spatial-sparql-repository.ts
+++ b/src/driven/persistence/spatial-sparql-repository.ts
@@ -1,4 +1,4 @@
-import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { NUTS_VERSION, PREFIX, PUBLIC_GRAPH } from "../../../config";
 import { extractResultsFromAllSettled } from "../../../platform/promises";
 import { Iri } from "../../core/domain/shared/iri";
 import { SpatialRepository } from "../../core/port/driven/persistence/spatial-repository";
@@ -17,7 +17,6 @@ export class SpatialSparqlRepository implements SpatialRepository {
   async findById(id: Iri): Promise<Spatial> {
     const query = `
       ${PREFIX.skos}
-      ${PREFIX.nutss}
       ${PREFIX.time}
       ${PREFIX.mu}
 
@@ -25,7 +24,7 @@ export class SpatialSparqlRepository implements SpatialRepository {
       WHERE {
         GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {
           ?uri a skos:Concept;
-               skos:inScheme nutss:2024;
+               skos:inScheme ${sparqlEscapeUri(NUTS_VERSION)};
                mu:uuid ?uuid;
                skos:prefLabel ?prefLabel;
                skos:notation ?notation.

--- a/src/driven/persistence/spatial-sparql-repository.ts
+++ b/src/driven/persistence/spatial-sparql-repository.ts
@@ -1,0 +1,61 @@
+import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { extractResultsFromAllSettled } from "../../../platform/promises";
+import { Iri } from "../../core/domain/shared/iri";
+import { SpatialRepository } from "../../core/port/driven/persistence/spatial-repository";
+import { SparqlQuerying } from "./sparql-querying";
+import { sparqlEscapeUri } from "../../../mu-helper";
+import { Spatial } from "../../core/domain/spatial";
+import { NotFoundError } from "../../core/domain/shared/lpdc-error";
+
+export class SpatialSparqlRepository implements SpatialRepository {
+  protected readonly querying: SparqlQuerying;
+
+  constructor(endpoint?: string) {
+    this.querying = new SparqlQuerying(endpoint);
+  }
+
+  async findById(id: Iri): Promise<Spatial> {
+    const query = `
+      ${PREFIX.skos}
+      ${PREFIX.nutss}
+      ${PREFIX.time}
+      ${PREFIX.mu}
+
+      SELECT DISTINCT ?uri ?uuid ?prefLabel ?notation ?endDate
+      WHERE {
+        GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {
+          ?uri a skos:Concept;
+               skos:inScheme nutss:2024;
+               mu:uuid ?uuid;
+               skos:prefLabel ?prefLabel;
+               skos:notation ?notation.
+          OPTIONAL {
+            ?uri time:hasEnd ?endDate.
+          }
+        }
+        VALUES ?uri {
+          ${sparqlEscapeUri(id)}
+        }
+      }`;
+
+    const [queryResult] = await extractResultsFromAllSettled([
+      this.querying.singleRow(query),
+    ]);
+
+    if (!queryResult) {
+      throw new NotFoundError(`No spatial resource found with URI: ${id}`);
+    }
+
+    const endDate = queryResult["endDate"]
+      ? new Date(queryResult["endDate"].value)
+      : undefined;
+
+    return new Spatial(
+      new Iri(queryResult["uri"].value),
+      queryResult["uuid"].value,
+      queryResult["prefLabel"].value,
+      queryResult["notation"].value,
+      endDate,
+    );
+  }
+}

--- a/test/core/application/validate-instance-for-publish-application-service.it-test.ts
+++ b/test/core/application/validate-instance-for-publish-application-service.it-test.ts
@@ -749,11 +749,65 @@ describe("ValidateInstanceForPublishApplicationService", () => {
       ]);
     });
 
+    test("results in two errors when an competent authority without status is provided and an expired spatial", async () => {
+      const expiredSpatial = anExpiredSpatial().build();
+      await spatialRepository.save(expiredSpatial);
+
+      const authority = aBestuurseenheid().withStatus(undefined).build();
+      await bestuurseenheidRepository.save(authority);
+
+      const bestuurseenheid = aBestuurseenheid().build();
+      const instance = aFullInstance()
+        .withCompetentAuthorities([authority.id])
+        .withSpatials([expiredSpatial.id])
+        .build();
+      await instanceRepository.save(bestuurseenheid, instance);
+
+      const errorList =
+        await validateInstanceForPublishApplicationService.validate(
+          instance.id,
+          bestuurseenheid,
+        );
+
+      expect(errorList).toEqual([
+        { message: INACTIVE_AUTHORITY_ERROR_MESSAGE },
+        { message: EXPIRED_SPATIAL_ERROR_MESSAGE },
+      ]);
+    });
+
     test("results in two errors when an inactive executing authority is provided and an expired spatial", async () => {
       const expiredSpatial = anExpiredSpatial().build();
       await spatialRepository.save(expiredSpatial);
 
       const inactiveAuthority = anInactiveBestuurseenheid().build();
+      await bestuurseenheidRepository.save(inactiveAuthority);
+
+      const bestuurseenheid = aBestuurseenheid().build();
+      const instance = aFullInstance()
+        .withExecutingAuthorities([inactiveAuthority.id])
+        .withSpatials([expiredSpatial.id])
+        .build();
+      await instanceRepository.save(bestuurseenheid, instance);
+
+      const errorList =
+        await validateInstanceForPublishApplicationService.validate(
+          instance.id,
+          bestuurseenheid,
+        );
+
+      expect(errorList).toEqual([
+        { message: INACTIVE_AUTHORITY_ERROR_MESSAGE },
+        { message: EXPIRED_SPATIAL_ERROR_MESSAGE },
+      ]);
+    });
+
+    test("results in two errors when an executing authority without status is provided and an expired spatial", async () => {
+      const expiredSpatial = anExpiredSpatial().build();
+      await spatialRepository.save(expiredSpatial);
+
+      const inactiveAuthority = aBestuurseenheid()
+        .withStatus(undefined)
+        .build();
       await bestuurseenheidRepository.save(inactiveAuthority);
 
       const bestuurseenheid = aBestuurseenheid().build();
@@ -786,6 +840,33 @@ describe("ValidateInstanceForPublishApplicationService", () => {
       const instance = aFullInstance()
         .withCompetentAuthorities([inactiveAuthority.id])
         .withExecutingAuthorities([inactiveAuthority.id])
+        .withSpatials([expiredSpatial.id])
+        .build();
+      await instanceRepository.save(bestuurseenheid, instance);
+
+      const errorList =
+        await validateInstanceForPublishApplicationService.validate(
+          instance.id,
+          bestuurseenheid,
+        );
+
+      expect(errorList).toEqual([
+        { message: INACTIVE_AUTHORITY_ERROR_MESSAGE },
+        { message: EXPIRED_SPATIAL_ERROR_MESSAGE },
+      ]);
+    });
+
+    test("results in two errors when a competent and executing authority without status is provided as well as an expired spatial", async () => {
+      const expiredSpatial = anExpiredSpatial().build();
+      await spatialRepository.save(expiredSpatial);
+
+      const authority = aBestuurseenheid().withStatus(undefined).build();
+      await bestuurseenheidRepository.save(authority);
+
+      const bestuurseenheid = aBestuurseenheid().build();
+      const instance = aFullInstance()
+        .withCompetentAuthorities([authority.id])
+        .withExecutingAuthorities([authority.id])
         .withSpatials([expiredSpatial.id])
         .build();
       await instanceRepository.save(bestuurseenheid, instance);

--- a/test/core/domain/bestuurseenheid-test-builder.ts
+++ b/test/core/domain/bestuurseenheid-test-builder.ts
@@ -25,21 +25,98 @@ export function aBestuurseenheid(): BestuurseenheidTestBuilder {
     ]);
 }
 
+export function someCompetentAuthorities(): BestuurseenheidTestBuilder[] {
+  const pepingen = new BestuurseenheidTestBuilder()
+    .withId(BestuurseenheidTestBuilder.PEPINGEN_IRI)
+    .withUuid(BestuurseenheidTestBuilder.PEPINGEN_UUID)
+    .withPrefLabel("Pepingen")
+    .withClassificatieCode(BestuurseenheidClassificatieCode.GEMEENTE)
+    .withStatus(BestuurseenheidStatusCode.ACTIVE)
+    .withSpatials([
+      BestuurseenheidTestBuilder.SPATIAL_1_IRI,
+      BestuurseenheidTestBuilder.SPATIAL_2_IRI,
+    ]);
+
+  const houthalenHelchteren = new BestuurseenheidTestBuilder()
+    .withId(BestuurseenheidTestBuilder.HOUTHALEN_HELCHTEREN_IRI)
+    .withUuid(BestuurseenheidTestBuilder.HOUTHALEN_HELCHTEREN_UUID)
+    .withPrefLabel("Houthalen-Helchteren")
+    .withClassificatieCode(BestuurseenheidClassificatieCode.GEMEENTE)
+    .withStatus(BestuurseenheidStatusCode.ACTIVE)
+    .withSpatials([
+      BestuurseenheidTestBuilder.SPATIAL_1_IRI,
+      BestuurseenheidTestBuilder.SPATIAL_2_IRI,
+    ]);
+
+  const borgloon = new BestuurseenheidTestBuilder()
+    .withId(BestuurseenheidTestBuilder.BORGLOON_IRI)
+    .withUuid(BestuurseenheidTestBuilder.BORGLOON_UUID)
+    .withPrefLabel("Borgloon")
+    .withClassificatieCode(BestuurseenheidClassificatieCode.GEMEENTE)
+    .withStatus(BestuurseenheidStatusCode.ACTIVE)
+    .withSpatials([
+      BestuurseenheidTestBuilder.SPATIAL_1_IRI,
+      BestuurseenheidTestBuilder.SPATIAL_2_IRI,
+    ]);
+
+  return [pepingen, houthalenHelchteren, borgloon];
+}
+
+export function someExecutingAuthorities(): BestuurseenheidTestBuilder[] {
+  const pepingen = new BestuurseenheidTestBuilder()
+    .withId(BestuurseenheidTestBuilder.PEPINGEN_IRI)
+    .withUuid(BestuurseenheidTestBuilder.PEPINGEN_UUID)
+    .withPrefLabel("Pepingen")
+    .withClassificatieCode(BestuurseenheidClassificatieCode.GEMEENTE)
+    .withStatus(BestuurseenheidStatusCode.ACTIVE)
+    .withSpatials([
+      BestuurseenheidTestBuilder.SPATIAL_1_IRI,
+      BestuurseenheidTestBuilder.SPATIAL_2_IRI,
+    ]);
+
+  const oudHeverlee = new BestuurseenheidTestBuilder()
+    .withId(BestuurseenheidTestBuilder.OUD_HEVERLEE_IRI)
+    .withUuid(BestuurseenheidTestBuilder.OUD_HEVERLEE_UUID)
+    .withPrefLabel("Oud-Heverlee")
+    .withClassificatieCode(BestuurseenheidClassificatieCode.GEMEENTE)
+    .withStatus(BestuurseenheidStatusCode.ACTIVE)
+    .withSpatials([
+      BestuurseenheidTestBuilder.SPATIAL_1_IRI,
+      BestuurseenheidTestBuilder.SPATIAL_2_IRI,
+    ]);
+
+  return [pepingen, oudHeverlee];
+}
+
 export class BestuurseenheidTestBuilder {
+  public static readonly PEPINGEN_UUID =
+    "73840d393bd94828f0903e8357c7f328d4bf4b8fbd63adbfa443e784f056a589";
   public static readonly PEPINGEN_IRI = buildBestuurseenheidIri(
-    "73840d393bd94828f0903e8357c7f328d4bf4b8fbd63adbfa443e784f056a589",
+    BestuurseenheidTestBuilder.PEPINGEN_UUID,
   );
+
+  public static readonly HOUTHALEN_HELCHTEREN_UUID =
+    "d760812063231cc45ced3fa65a7cd54920329178c8df7e891aa12db442e6606a";
   public static readonly HOUTHALEN_HELCHTEREN_IRI = buildBestuurseenheidIri(
-    "d760812063231cc45ced3fa65a7cd54920329178c8df7e891aa12db442e6606a",
+    BestuurseenheidTestBuilder.HOUTHALEN_HELCHTEREN_UUID,
   );
+
+  public static readonly BORGLOON_UUID =
+    "05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f";
   public static readonly BORGLOON_IRI = buildBestuurseenheidIri(
-    "05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f",
+    BestuurseenheidTestBuilder.BORGLOON_UUID,
   );
+
+  public static readonly OUD_HEVERLEE_UUID =
+    "319db6e275f281d0280da90d6f6aba3462f4e47b6f53a34639feb91015a5822b";
   public static readonly OUD_HEVERLEE_IRI = buildBestuurseenheidIri(
-    "319db6e275f281d0280da90d6f6aba3462f4e47b6f53a34639feb91015a5822b",
+    BestuurseenheidTestBuilder.OUD_HEVERLEE_UUID,
   );
+
+  public static readonly ASSENEDE_UUID =
+    "e971816acb021c37576835e6a96922442628956fd029d885fd849c9f07414469";
   public static readonly ASSENEDE_IRI = buildBestuurseenheidIri(
-    "e971816acb021c37576835e6a96922442628956fd029d885fd849c9f07414469",
+    BestuurseenheidTestBuilder.ASSENEDE_UUID,
   );
 
   public static readonly SPATIAL_1_IRI = buildNutsCodeIri(

--- a/test/core/domain/bestuurseenheid-test-builder.ts
+++ b/test/core/domain/bestuurseenheid-test-builder.ts
@@ -25,6 +25,20 @@ export function aBestuurseenheid(): BestuurseenheidTestBuilder {
     ]);
 }
 
+export function anInactiveBestuurseenheid(): BestuurseenheidTestBuilder {
+  const administrativeUnitUuid = uuid();
+  return new BestuurseenheidTestBuilder()
+    .withId(buildBestuurseenheidIri(administrativeUnitUuid))
+    .withUuid(administrativeUnitUuid)
+    .withPrefLabel("Inactive")
+    .withClassificatieCode(BestuurseenheidClassificatieCode.GEMEENTE)
+    .withStatus(BestuurseenheidStatusCode.INACTIVE)
+    .withSpatials([
+      BestuurseenheidTestBuilder.SPATIAL_1_IRI,
+      BestuurseenheidTestBuilder.SPATIAL_2_IRI,
+    ]);
+}
+
 export function someCompetentAuthorities(): BestuurseenheidTestBuilder[] {
   const pepingen = new BestuurseenheidTestBuilder()
     .withId(BestuurseenheidTestBuilder.PEPINGEN_IRI)

--- a/test/core/domain/bestuurseenheid-test-builder.ts
+++ b/test/core/domain/bestuurseenheid-test-builder.ts
@@ -2,6 +2,7 @@ import { Iri } from "../../../src/core/domain/shared/iri";
 import {
   Bestuurseenheid,
   BestuurseenheidClassificatieCode,
+  BestuurseenheidStatusCode,
 } from "../../../src/core/domain/bestuurseenheid";
 import { uuid } from "../../../mu-helper";
 import {
@@ -17,6 +18,7 @@ export function aBestuurseenheid(): BestuurseenheidTestBuilder {
     .withUuid(bestuurseenheidUuid)
     .withPrefLabel("Aarschot")
     .withClassificatieCode(BestuurseenheidClassificatieCode.GEMEENTE)
+    .withStatus(BestuurseenheidStatusCode.ACTIVE)
     .withSpatials([
       BestuurseenheidTestBuilder.SPATIAL_1_IRI,
       BestuurseenheidTestBuilder.SPATIAL_2_IRI,
@@ -51,6 +53,7 @@ export class BestuurseenheidTestBuilder {
   private uuid: string;
   private prefLabel: string;
   private classificatieCode: BestuurseenheidClassificatieCode;
+  private status: BestuurseenheidStatusCode;
   private spatials: Iri[];
 
   public withId(id: Iri): BestuurseenheidTestBuilder {
@@ -75,6 +78,13 @@ export class BestuurseenheidTestBuilder {
     return this;
   }
 
+  public withStatus(
+    status: BestuurseenheidStatusCode,
+  ): BestuurseenheidTestBuilder {
+    this.status = status;
+    return this;
+  }
+
   public withSpatials(spatials: Iri[]): BestuurseenheidTestBuilder {
     this.spatials = spatials;
     return this;
@@ -86,6 +96,7 @@ export class BestuurseenheidTestBuilder {
       this.uuid,
       this.prefLabel,
       this.classificatieCode,
+      this.status,
       this.spatials,
     );
   }

--- a/test/core/domain/bestuurseenheid.unit-test.ts
+++ b/test/core/domain/bestuurseenheid.unit-test.ts
@@ -2,6 +2,7 @@ import { aBestuurseenheid } from "./bestuurseenheid-test-builder";
 import {
   Bestuurseenheid,
   BestuurseenheidClassificatieCode,
+  BestuurseenheidStatusCode,
 } from "../../../src/core/domain/bestuurseenheid";
 import { uuid } from "../../../mu-helper";
 import { Iri } from "../../../src/core/domain/shared/iri";
@@ -16,6 +17,7 @@ test("Undefined id throws error", () => {
         uuid(),
         "Pepingen",
         BestuurseenheidClassificatieCode.GEMEENTE,
+        BestuurseenheidStatusCode.ACTIVE,
         [],
       ),
   ).toThrowWithMessage(InvariantError, "id mag niet ontbreken");
@@ -29,6 +31,7 @@ test("Invalid iri id throws error", () => {
         uuid(),
         "Pepingen",
         BestuurseenheidClassificatieCode.GEMEENTE,
+        BestuurseenheidStatusCode.ACTIVE,
         [],
       ),
   ).toThrowWithMessage(InvariantError, "iri mag niet leeg zijn");
@@ -42,6 +45,7 @@ test("Undefined uuid throws error", () => {
         undefined,
         "Pepingen",
         BestuurseenheidClassificatieCode.GEMEENTE,
+        BestuurseenheidStatusCode.ACTIVE,
         [],
       ),
   ).toThrowWithMessage(InvariantError, "uuid mag niet ontbreken");
@@ -55,6 +59,7 @@ test("Undefined prefLabel throws error", () => {
         uuid(),
         undefined,
         BestuurseenheidClassificatieCode.GEMEENTE,
+        BestuurseenheidStatusCode.ACTIVE,
         [],
       ),
   ).toThrowWithMessage(InvariantError, "prefLabel mag niet ontbreken");
@@ -68,6 +73,7 @@ test("Undefined classificatieCode throws error", () => {
         uuid(),
         "prefLabel",
         undefined,
+        BestuurseenheidStatusCode.ACTIVE,
         [],
       ),
   ).toThrowWithMessage(InvariantError, "classificatieCode mag niet ontbreken");
@@ -79,6 +85,20 @@ test("Undefined classificatieCode does not throw error for ABB", () => {
       Bestuurseenheid.abb,
       uuid(),
       "prefLabel",
+      undefined,
+      BestuurseenheidStatusCode.ACTIVE,
+      [],
+    ),
+  ).not.toBeUndefined();
+});
+
+test("Undefined status does not throw an error", () => {
+  expect(
+    new Bestuurseenheid(
+      new Iri("http://anIri"),
+      uuid(),
+      "prefLabel",
+      BestuurseenheidClassificatieCode.GEMEENTE,
       undefined,
       [],
     ),

--- a/test/core/domain/instance-test-builder.ts
+++ b/test/core/domain/instance-test-builder.ts
@@ -4,8 +4,6 @@ import {
   buildBestuurseenheidIri,
   buildConceptIri,
   buildConceptSnapshotIri,
-  buildNutsCodeIri,
-  randomNumber,
 } from "./iri-test-builder";
 import { uuid } from "../../../mu-helper";
 import { FormatPreservingDate } from "../../../src/core/domain/format-preserving-date";
@@ -55,6 +53,7 @@ import {
   anotherFullLegalResourceForInstance,
 } from "./legal-resource-test-builder";
 import { Language } from "../../../src/core/domain/language";
+import { SpatialTestBuilder } from "./spatial-test-builder";
 
 export function aMinimalInstance(): InstanceBuilder {
   const uniqueId = uuid();
@@ -168,8 +167,8 @@ export class InstanceTestBuilder {
   public static readonly STATUS = InstanceStatusType.ONTWERP;
 
   public static readonly SPATIALS = [
-    buildNutsCodeIri(randomNumber(10000, 19999)),
-    buildNutsCodeIri(randomNumber(20000, 29999)),
+    SpatialTestBuilder.PEPINGEN_SPATIAL_IRI,
+    SpatialTestBuilder.OUD_HEVERLEE_SPATIAL_IRI,
   ];
 
   public static readonly COMPETENT_AUTHORITIES = [

--- a/test/core/domain/spatial-test-builder.ts
+++ b/test/core/domain/spatial-test-builder.ts
@@ -1,0 +1,85 @@
+import { uuid } from "../../../mu-helper";
+import { Iri } from "../../../src/core/domain/shared/iri";
+import { Spatial } from "../../../src/core/domain/spatial";
+import { buildNutsCodeIri } from "./iri-test-builder";
+
+export function aSpatial(): SpatialTestBuilder {
+  const spatialUuid = uuid();
+  return new SpatialTestBuilder()
+    .withId(buildNutsCodeIri(spatialUuid))
+    .withUuid(spatialUuid)
+    .withPrefLabel("A valid spatial without end date")
+    .withNotation("0123");
+}
+
+export function anExpiredSpatial(): SpatialTestBuilder {
+  const spatialUuid = uuid();
+  return new SpatialTestBuilder()
+    .withId(buildNutsCodeIri(spatialUuid))
+    .withUuid(spatialUuid)
+    .withPrefLabel("A valid spatial with an end date in the past")
+    .withNotation("4567")
+    .withEndDate(new Date("2000-01-01"));
+}
+
+export function aSpatialWithFutureEndDate(): SpatialTestBuilder {
+  const spatialUuid = uuid();
+  return new SpatialTestBuilder()
+    .withId(buildNutsCodeIri(spatialUuid))
+    .withUuid(spatialUuid)
+    .withPrefLabel("A valid spatial with an end date in the future")
+    .withNotation("8910")
+    .withEndDate(new Date("2222-01-01"));
+}
+
+export class SpatialTestBuilder {
+  public static readonly PEPINGEN_SPATIAL_UUID = 24123064;
+  public static readonly PEPINGEN_SPATIAL_IRI = buildNutsCodeIri(
+    SpatialTestBuilder.PEPINGEN_SPATIAL_UUID,
+  );
+  public static readonly OUD_HEVERLEE_SPATIAL_UUID = 24224086;
+  public static readonly OUD_HEVERLEE_SPATIAL_IRI = buildNutsCodeIri(
+    SpatialTestBuilder.OUD_HEVERLEE_SPATIAL_UUID,
+  );
+
+  private id: Iri;
+  private uuid: string;
+  private prefLabel: string;
+  private notation: string;
+  private endDate: Date;
+
+  public withId(id: Iri): SpatialTestBuilder {
+    this.id = id;
+    return this;
+  }
+
+  public withUuid(uuid: string): SpatialTestBuilder {
+    this.uuid = uuid;
+    return this;
+  }
+
+  public withPrefLabel(prefLabel: string): SpatialTestBuilder {
+    this.prefLabel = prefLabel;
+    return this;
+  }
+
+  public withNotation(notation: string): SpatialTestBuilder {
+    this.notation = notation;
+    return this;
+  }
+
+  public withEndDate(endDate: Date): SpatialTestBuilder {
+    this.endDate = endDate;
+    return this;
+  }
+
+  public build(): Spatial {
+    return new Spatial(
+      this.id,
+      this.uuid,
+      this.prefLabel,
+      this.notation,
+      this.endDate,
+    );
+  }
+}

--- a/test/core/domain/spatial.unit-test.ts
+++ b/test/core/domain/spatial.unit-test.ts
@@ -1,0 +1,104 @@
+import { Spatial } from "../../../src/core/domain/spatial";
+import { uuid } from "../../../mu-helper";
+import { Iri } from "../../../src/core/domain/shared/iri";
+import { InvariantError } from "../../../src/core/domain/shared/lpdc-error";
+
+describe("constructor", () => {
+  test("throws an error for an undefined id", async () => {
+    expect(
+      () => new Spatial(undefined, uuid(), "Test", "1234", new Date()),
+    ).toThrowWithMessage(InvariantError, "id mag niet ontbreken");
+  });
+
+  test("throws an error for an invalid iri id", async () => {
+    expect(
+      () => new Spatial(new Iri("   "), uuid(), "Test", "1234", new Date()),
+    ).toThrowWithMessage(InvariantError, "iri mag niet leeg zijn");
+  });
+
+  test("throws an error for an undefined uuid", () => {
+    expect(
+      () =>
+        new Spatial(
+          new Iri("http://anIri"),
+          undefined,
+          "Test",
+          "1234",
+          new Date(),
+        ),
+    ).toThrowWithMessage(InvariantError, "uuid mag niet ontbreken");
+  });
+
+  test("throws an error for an undefined prefLabel", async () => {
+    expect(
+      () =>
+        new Spatial(
+          new Iri("http://anIri"),
+          uuid(),
+          undefined,
+          "1234",
+          new Date(),
+        ),
+    ).toThrowWithMessage(InvariantError, "prefLabel mag niet ontbreken");
+  });
+
+  test("throws an error for an undefined notation", async () => {
+    expect(
+      () =>
+        new Spatial(
+          new Iri("http://anIri"),
+          uuid(),
+          "Test",
+          undefined,
+          new Date(),
+        ),
+    ).toThrowWithMessage(InvariantError, "notation mag niet ontbreken");
+  });
+
+  test("does not throw an error for an undefined end date", async () => {
+    expect(
+      () =>
+        new Spatial(new Iri("http://anIri"), uuid(), "Test", "1234", undefined),
+    ).not.toBeUndefined();
+  });
+
+  test("does not throw an error for a missing end date", async () => {
+    expect(
+      () => new Spatial(new Iri("http://anIri"), uuid(), "Test", "1234"),
+    ).not.toBeUndefined();
+  });
+});
+
+describe("isExpired", () => {
+  test("returns false for a spatial without end date", async () => {
+    const spatial = new Spatial(
+      new Iri("http://anIri"),
+      uuid(),
+      "Test",
+      "1234",
+    );
+    expect(spatial.isExpired).toBeFalse;
+  });
+
+  test("returns false for a spatial with an end date in the future", async () => {
+    const spatial = new Spatial(
+      new Iri("http://anIri"),
+      uuid(),
+      "Test",
+      "1234",
+      new Date("2222-01-01"),
+    );
+    expect(spatial.isExpired).toBeFalse;
+  });
+
+  test("returns true for a spatial with an end date in the past", async () => {
+    const spatial = new Spatial(
+      new Iri("http://anIri"),
+      uuid(),
+      "Test",
+      "1234",
+      new Date("1999-01-01"),
+    );
+    expect(spatial.isExpired).toBeTrue;
+  });
+});

--- a/test/data-integrity-validation/instance-publish-data-integrity.it-test.ts
+++ b/test/data-integrity-validation/instance-publish-data-integrity.it-test.ts
@@ -48,6 +48,7 @@ const validateInstanceForPublishApplicationService =
   new ValidateInstanceForPublishApplicationService(
     formApplicationService,
     instanceRepository,
+    bestuurseenheidRepository,
   );
 
 describe("Instance publish validation", () => {

--- a/test/data-integrity-validation/instance-publish-data-integrity.it-test.ts
+++ b/test/data-integrity-validation/instance-publish-data-integrity.it-test.ts
@@ -17,12 +17,14 @@ import { FormDefinitionFileRepository } from "../../src/driven/persistence/form-
 import { CodeSparqlRepository } from "../../src/driven/persistence/code-sparql-repository";
 import { ConceptSnapshotSparqlRepository } from "../../src/driven/persistence/concept-snapshot-sparql-repository";
 import { InstanceSparqlRepository } from "../../src/driven/persistence/instance-sparql-repository";
+import { SpatialSparqlTestRepository } from "../driven/persistence/spatial-sparql-test-repository";
 
 const endPoint = END2END_TEST_SPARQL_ENDPOINT;
 const directDatabaseAccess = new DirectDatabaseAccess(endPoint);
 const bestuurseenheidRepository = new BestuurseenheidSparqlTestRepository(
   endPoint,
 );
+const spatialRepository = new SpatialSparqlTestRepository(endPoint);
 const conceptRepository = new ConceptSparqlRepository(endPoint);
 const conceptSnapshotRepository = new ConceptSnapshotSparqlRepository(endPoint);
 const instanceRepository = new InstanceSparqlRepository(endPoint);
@@ -49,6 +51,7 @@ const validateInstanceForPublishApplicationService =
     formApplicationService,
     instanceRepository,
     bestuurseenheidRepository,
+    spatialRepository,
   );
 
 describe("Instance publish validation", () => {

--- a/test/driven/persistence/bestuurseenheid-sparql-test-repository.ts
+++ b/test/driven/persistence/bestuurseenheid-sparql-test-repository.ts
@@ -8,7 +8,7 @@ import {
   BestuurseenheidClassificatieCode,
   BestuurseenheidStatusCode,
 } from "../../../src/core/domain/bestuurseenheid";
-import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { NUTS_VERSION, PREFIX, PUBLIC_GRAPH } from "../../../config";
 import { sparqlEscapeString, sparqlEscapeUri, uuid } from "../../../mu-helper";
 import { buildWerkingsgebiedenIri } from "../../core/domain/iri-test-builder";
 import { NotFoundError } from "../../../src/core/domain/shared/lpdc-error";
@@ -35,7 +35,6 @@ export class BestuurseenheidSparqlTestRepository extends BestuurseenheidSparqlRe
             ${PREFIX.besluit}
             ${PREFIX.mu}
             ${PREFIX.skos}
-            ${PREFIX.nutss}
             ${PREFIX.regorg}
 
             INSERT DATA {
@@ -49,7 +48,8 @@ export class BestuurseenheidSparqlTestRepository extends BestuurseenheidSparqlRe
                       .flatMap((wgs) => [
                         `${sparqlEscapeUri(bestuurseenheid.id)} besluit:werkingsgebied ${sparqlEscapeUri(wgs[1])}`,
                         `${sparqlEscapeUri(wgs[1])} skos:exactMatch ${sparqlEscapeUri(wgs[0])}`,
-                        `${sparqlEscapeUri(wgs[0])} skos:inScheme nutss:2024`,
+                        `${sparqlEscapeUri(wgs[0])} skos:inScheme ${sparqlEscapeUri(NUTS_VERSION)}`,
+                        `${sparqlEscapeUri(wgs[0])} skos:topConceptOf ${sparqlEscapeUri(NUTS_VERSION)}`,
                       ])
                       .join(" .\n")} .
                 }

--- a/test/driven/persistence/bestuurseenheid-sparql-test-repository.ts
+++ b/test/driven/persistence/bestuurseenheid-sparql-test-repository.ts
@@ -44,7 +44,7 @@ export class BestuurseenheidSparqlTestRepository extends BestuurseenheidSparqlRe
                     ${sparqlEscapeUri(bestuurseenheid.id)} skos:prefLabel ${sparqlEscapeString(bestuurseenheid.prefLabel)} .
                     ${classificatieUri ? `${sparqlEscapeUri(bestuurseenheid.id)} besluit:classificatie ${sparqlEscapeUri(classificatieUri)} .` : ""}
                     ${sparqlEscapeUri(bestuurseenheid.id)} mu:uuid ${sparqlEscapeString(bestuurseenheid.uuid)} .
-                    ${sparqlEscapeUri(bestuurseenheid.id)} regorg:orgStatus ${sparqlEscapeUri(statusUri)} .
+                    ${statusUri ? `${sparqlEscapeUri(bestuurseenheid.id)} regorg:orgStatus ${sparqlEscapeUri(statusUri)} .` : ""}
                     ${werkingsgebiedenSpatials
                       .flatMap((wgs) => [
                         `${sparqlEscapeUri(bestuurseenheid.id)} besluit:werkingsgebied ${sparqlEscapeUri(wgs[1])}`,

--- a/test/driven/persistence/spatial-repository.it-test.ts
+++ b/test/driven/persistence/spatial-repository.it-test.ts
@@ -1,7 +1,7 @@
 import { NotFoundError } from "../../../src/core/domain/shared/lpdc-error";
 import { aSpatial } from "../../core/domain/spatial-test-builder";
 import { TEST_SPARQL_ENDPOINT } from "../../test.config";
-import { SpatialSparqlTestRepository } from "./SpatialSparqlTestRepository";
+import { SpatialSparqlTestRepository } from "./spatial-sparql-test-repository";
 import { Iri } from "../../../src/core/domain/shared/iri";
 
 describe("SpatialRepository", () => {

--- a/test/driven/persistence/spatial-repository.it-test.ts
+++ b/test/driven/persistence/spatial-repository.it-test.ts
@@ -1,0 +1,53 @@
+import { NotFoundError } from "../../../src/core/domain/shared/lpdc-error";
+import { aSpatial } from "../../core/domain/spatial-test-builder";
+import { TEST_SPARQL_ENDPOINT } from "../../test.config";
+import { SpatialSparqlTestRepository } from "./SpatialSparqlTestRepository";
+import { Iri } from "../../../src/core/domain/shared/iri";
+
+describe("SpatialRepository", () => {
+  const repository = new SpatialSparqlTestRepository(TEST_SPARQL_ENDPOINT);
+
+  describe("findById", () => {
+    test("it finds a stored spatial given its id", async () => {
+      const spatial = aSpatial().build();
+      await repository.save(spatial);
+
+      const foundSpatial = await repository.findById(spatial.id);
+      expect(foundSpatial).toEqual(spatial);
+    });
+
+    test("it finds the correct stored spatial among others given its id", async () => {
+      const spatial = aSpatial().build();
+      await repository.save(spatial);
+
+      await repository.save(aSpatial().build());
+      await repository.save(aSpatial().build());
+      await repository.save(aSpatial().build());
+
+      const foundSpatial = await repository.findById(spatial.id);
+      expect(foundSpatial).toEqual(spatial);
+    });
+
+    test("it finds a stored spatial without end date based on its id", async () => {
+      const spatial = aSpatial().withEndDate(undefined).build();
+      await repository.save(spatial);
+
+      const foundSpatial = await repository.findById(spatial.id);
+      expect(foundSpatial).toEqual(spatial);
+    });
+
+    test("it throws an error when an id for a non existing spatial is given", async () => {
+      const invalidSpatialId = new Iri("http://SpatialIdThatDoesNotExist");
+      await repository.save(aSpatial().build());
+      await repository.save(aSpatial().build());
+      await repository.save(aSpatial().build());
+
+      await expect(
+        repository.findById(invalidSpatialId),
+      ).rejects.toThrowWithMessage(
+        NotFoundError,
+        `No spatial resource found with URI: ${invalidSpatialId}`,
+      );
+    });
+  });
+});

--- a/test/driven/persistence/spatial-sparql-test-repository.ts
+++ b/test/driven/persistence/spatial-sparql-test-repository.ts
@@ -1,4 +1,4 @@
-import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { NUTS_VERSION, PREFIX, PUBLIC_GRAPH } from "../../../config";
 import { sparqlEscapeString, sparqlEscapeUri } from "../../../mu-helper";
 import { Spatial } from "../../../src/core/domain/spatial";
 import { SpatialSparqlRepository } from "../../../src/driven/persistence/spatial-sparql-repository";
@@ -15,7 +15,6 @@ export class SpatialSparqlTestRepository extends SpatialSparqlRepository {
 
     const query = `
     ${PREFIX.skos}
-    ${PREFIX.nutss}
     ${PREFIX.time}
     ${PREFIX.mu}
 
@@ -26,8 +25,8 @@ export class SpatialSparqlTestRepository extends SpatialSparqlRepository {
           skos:prefLabel ${sparqlEscapeString(spatial.prefLabel)};
           skos:notation ${sparqlEscapeString(spatial.notation)};
           ${dateString ? `time:hasEnd ${sparqlEscapeString(dateString)};` : ""}
-          skos:inScheme nutss:2024;
-          skos:topConceptOf nutss:2024.
+          skos:inScheme ${sparqlEscapeUri(NUTS_VERSION)};
+          skos:topConceptOf ${sparqlEscapeUri(NUTS_VERSION)}.
       }
     }
 `;

--- a/test/driven/persistence/spatial-sparql-test-repository.ts
+++ b/test/driven/persistence/spatial-sparql-test-repository.ts
@@ -1,0 +1,36 @@
+import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { sparqlEscapeString, sparqlEscapeUri } from "../../../mu-helper";
+import { Spatial } from "../../../src/core/domain/spatial";
+import { SpatialSparqlRepository } from "../../../src/driven/persistence/spatial-sparql-repository";
+
+export class SpatialSparqlTestRepository extends SpatialSparqlRepository {
+  constructor(endpoint?: string) {
+    super(endpoint);
+  }
+
+  async save(spatial: Spatial): Promise<void> {
+    const dateString = spatial.endDate
+      ? spatial.endDate.toLocaleDateString()
+      : undefined;
+
+    const query = `
+    ${PREFIX.skos}
+    ${PREFIX.nutss}
+    ${PREFIX.time}
+    ${PREFIX.mu}
+
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {
+        ${sparqlEscapeUri(spatial.id)} a skos:Concept;
+          mu:uuid ${sparqlEscapeString(spatial.uuid)};
+          skos:prefLabel ${sparqlEscapeString(spatial.prefLabel)};
+          skos:notation ${sparqlEscapeString(spatial.notation)};
+          ${dateString ? `time:hasEnd ${sparqlEscapeString(dateString)};` : ""}
+          skos:inScheme nutss:2024;
+          skos:topConceptOf nutss:2024.
+      }
+    }
+`;
+    await this.querying.insert(query);
+  }
+}


### PR DESCRIPTION
## Summary
Users should be shown an error message when they try to publish a product instance that has
- an inactive municipality as competent or executing authority
- an expired spatial as geographic scope.

## Proposed solution
The `ValidateInstanceForPublishApplicationService` already performs some validations on product instances before they can be published. This service is therefore extended with additional checks.

### Competent and executing authority
To enable checking for inactive organisations, it was opted to import the relevant status data from OrganisatiePortaal. This was done in a [PR](https://github.com/lblod/app-lpdc-digitaal-loket/pull/44) on the backend.

To be able the use this new status information, the `Bestuurseenheid` domain concept is extended with a new `status` property. Note that as not all organisations in LPDC actually have a status, it is allowed for this new property to be `undefined`, see the ticket for background discussion. Furthermore, the SPARQL query used in the `BestuurseenheidSparqlRepository` to retrieve administrative units from the triplestore was modified to include the status triple as optional value.

The `ValidateInstanceForPublishApplicationService` itself is extended such that it can use a `BestuurseenheidRepository` to retrieve the administrative units that are linked as competent and/or executing authorities to a product instance. The service's validation logic was extended to check that all assigned competent and executing authorities have as status *Active* or *In formation*. Note, organisations without a status are thus treated the same as organisations with the status *Inactive*.
The retrieval of the needed `Bestuureenheid` resources was implemented in the validation service itself as this is the first place where the actual `Instance` to validate is available. This is necessary to get the IRIs for the administrative units whose status to check. Alternatively, this could be done in `app.validateForPublish` and `app.publishInstance` similar to how currently the administrative unit for the logged in user is retrieved. But that would result in more (duplicated) business logic the `app`.

Notes:
- In the `Instance` domain concept I opted to keep the variables for competent and executing authorities as `Iri[]`. This way the `Bestuurseenheid` resources matching those IRIs are retrieved from storage only when needed, i.e. when validating a product instance for publication.

### Spatial
To validate whether a spatial is still valid we rely on the expiration date in the underlying NUTS LAU spatial code list. This code list was already added/updated in a previous [backend PR](https://github.com/lblod/app-lpdc-digitaal-loket/pull/34). In essence, the new validation boils down to checking whether a spatial has an expiration date (`time:hasEnd` predicate) and, if so, whether that date is in the past. Note that spatials without expiration date are considered to be valid indefinitely.

A new domain concept `Spatial` is added to the core domain layer as abstraction of the NUTS LAU spatial code list resource. In order to retrieve spatial resources from a triplestore, a new `SpatialRepository` port was added along with a specific implementation for SPARQL, the `SpatialSparqlRepository`. Note, not all fields in the code list are currently retrieved, for instance the `skos:definition` field part of the NUTS LAU code list resources is currently not used.

Similar to the above validation, the `ValidateInstanceForPublishApplicationService` is extended to be able to use the new `SpatialRepository`. The service's validation logic is extended to retrieve the `Spatial` resources assigned to a product instance and checking that none of them are expired. A spatial is expired when it has an expiration date **and** that expiration date is in the past.

## Expected error messages
The exact error messages that should be shown to the user were provided by business:
- Inactive authority: "*Het product dat je probeert te verzenden, is gelinkt aan een inactief bestuur. Kijk in de tab ‘eigenschappen’ de overheidsorganisatie na.*”
- Expired spatial: “*Het product dat je probeert te verzenden, is gelinkt aan een inactief bestuur. Kijk in de tab ‘eigenschappen’ het geografisch toepassingsgebied na.*”

## How to test
### Setup
1. Start a local LPDC stack and make sure the migrations for the organisation status data have been executed.
2. Configure your stack to use a local build of the `lpdc-management` service by adding something like the following to your `docker-compose.override.yml`:
``` yaml
lpdc-management:
  build:
    context: ../lpdc-management-service # Change to the correct local path for your configuration
    dockerfile: Dockerfile
  environment:
    NODE_ENV: "development"
```
3. In your local repository for the `lpdc-management` service checkout this PRs branch
4. In the LPDC app, locally build a version of the `lpdc-management` service

``` shell
# In the app directory
docker compose build --no-cache lpdc-management
docker compose up --build --force-recreate --no-deps -d lpdc-management
```

### Testing the new functionality
1. Use the frontend to login as some organisation, any with product instances will do.
5. Select an existing product instance. If you selected an already published product instance, click the "Product opnieuw bewerken" button in the top-right corner of the page to be able to edit the product instance.
6. Go to the Properties (*nl. Eigenschappen*) tab for the selected product instance. All relevant fields are located in the Authority (*nl. Bevoegdheid*) section.
7. For the Competent authority (*nl. Bevoegde overheid*) and Executing authority (*nl. Uitvoerende overheid*) fields an error should be shown in step 9 when one or more of the following municipalities is selected:
  - Borsbeek
  - Beveren
  - Kruibeke
  - Zwijndrecht
  - Hoeselt
  - Borgloon
  - Nazareth
  - De Pinte
  - Galmaarden
  - Gooik
  - Herne
  - Ham
  - Kortessem
  - Wachtebeke
  - Moerbeke
  - Melle
  - Merelbeke
  - Meulebeke
  - Ruiselede
8. The spatial (*nl. Geografisch toepassingsgebied*) field should result in an error in step 9 when it has one or more of the following values:
  - Beveren
  - Bilzen
  - Borgloon
  - Borsbeek
  - De Pinte
  - Galmaarden
  - Gooik
  - Ham
  - Hasselt (voor fusie 2025)
  - Herne
  - Hoeselt
  - Kortessem
  - Kruibeke
  - Lochristi (voor fusie 2025)
  - Lokeren (voor fusie 2025)
  - Melle
  - Merelbeke
  - Meulebeke
  - Moerbeke
  - Nazareth
  - Ruiselede
  - Tessenderlo
  - Tielt (voor fusie 2025)
  - Tongeren
  - Wachtebeke
  - Wingene (voor fusie 2025)
  - Zwijndrecht
9. After selecting appropriate values for fields, click the "Verzend naar Vlaamse overheid" button in the top-right corner. Confirm your publication request by clicking the button with the same text on the appearing modal. Any error messages triggered by your input will shown in a popups in the top-right corner.

Note: it is possible to select other organisations that municipalities as competent or executing authority. The expected behaviour with respect to showing errors is the same as with the municipalities.

### Running the provided tests
The tests defined as part of the `lpdc-management` service can be run by executing the `test/run-test.sh` script. Warning, this takes some time as it runs all tests, on my machine it takes a couple of minutes. Furthermore, one test is "expect" to fail, this is unrelated to the changes in this PR.

## Related tickets
- LPDC-1335