### PR TITLE
fix: relax authority publish validation for product instances

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -134,6 +134,7 @@ const validateInstanceForPublishApplicationService =
     instanceRepository,
     bestuurseenheidRepository,
     spatialRepository,
+    codeRepository,
   );
 
 const linkConceptToInstanceDomainService =

--- a/config.ts
+++ b/config.ts
@@ -26,6 +26,8 @@ const IPDC_API_KEY = process.env.IPDC_API_KEY;
 
 const NUTS_VERSION = "http://data.europa.eu/nuts/scheme/2024";
 
+const WEGWIJS_URL = "https://wegwijs.vlaanderen.be";
+
 const PREFIX = {
   rdf: "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
   skos: "PREFIX skos: <http://www.w3.org/2004/02/skos/core#>",
@@ -84,4 +86,5 @@ export {
   IPDC_API_ENDPOINT,
   IPDC_API_KEY,
   NUTS_VERSION,
+  WEGWIJS_URL,
 };

--- a/src/core/application/validate-instance-for-publish-application-service.ts
+++ b/src/core/application/validate-instance-for-publish-application-service.ts
@@ -10,6 +10,10 @@ import { Instance } from "../domain/instance";
 import { ENABLE_ADDRESS_VALIDATION } from "../../../config";
 import { BestuurseenheidRepository } from "../port/driven/persistence/bestuurseenheid-repository";
 import { SpatialRepository } from "../port/driven/persistence/spatial-repository";
+import {
+  CodeRepository,
+  CodeSchema,
+} from "../port/driven/persistence/code-repository";
 
 export const INACTIVE_AUTHORITY_ERROR_MESSAGE =
   "Het product dat je probeert te verzenden, is gelinkt aan een inactief bestuur. Kijk in de tab ‘eigenschappen’ de overheidsorganisatie na.";
@@ -21,17 +25,20 @@ export class ValidateInstanceForPublishApplicationService {
   private readonly _instanceRepository: InstanceRepository;
   private readonly _bestuurseenheidRepository: BestuurseenheidRepository;
   private readonly _spatialRepository: SpatialRepository;
+  private readonly _codeRepository: CodeRepository;
 
   constructor(
     formApplicationService: FormApplicationService,
     instanceRepository: InstanceRepository,
     bestuurseenheidRepository: BestuurseenheidRepository,
     spatialRepository: SpatialRepository,
+    codeRepository: CodeRepository,
   ) {
     this._formApplicationService = formApplicationService;
     this._instanceRepository = instanceRepository;
     this._bestuurseenheidRepository = bestuurseenheidRepository;
     this._spatialRepository = spatialRepository;
+    this._codeRepository = codeRepository;
   }
 
   async validate(
@@ -69,25 +76,50 @@ export class ValidateInstanceForPublishApplicationService {
     return this.tryValidateForPublish(instance);
   }
 
+  private collectAndGroupAuthorityUris(instance: Instance) {
+    const ovoCodeIris = [];
+    const administrativeUnitIris = [];
+
+    [
+      ...new Set(
+        instance.competentAuthorities.concat(instance.executingAuthorities),
+      ),
+    ].forEach((iri) =>
+      iri.isOvoCodeIri
+        ? ovoCodeIris.push(iri)
+        : administrativeUnitIris.push(iri),
+    );
+
+    return { ovoCodeIris, administrativeUnitIris };
+  }
+
   private async validateAuthorities(
     instance: Instance,
   ): Promise<ValidationError> {
     try {
-      const competentAuthorities = await Promise.all(
-        instance.competentAuthorities.flatMap(
+      const { ovoCodeIris, administrativeUnitIris } =
+        this.collectAndGroupAuthorityUris(instance);
+
+      const ovoCodeAuthorities = await Promise.all(
+        ovoCodeIris.flatMap(
+          async (uri) =>
+            await this._codeRepository.exists(CodeSchema.IPDCOrganisaties, uri),
+        ),
+      );
+
+      if (ovoCodeAuthorities.includes(false)) {
+        return { message: INACTIVE_AUTHORITY_ERROR_MESSAGE };
+      }
+
+      const authorityUnits = await Promise.all(
+        administrativeUnitIris.flatMap(
           async (uri) => await this._bestuurseenheidRepository.findById(uri),
         ),
       );
 
-      const executingAuthorities = await Promise.all(
-        instance.executingAuthorities.flatMap(
-          async (uri) => await this._bestuurseenheidRepository.findById(uri),
-        ),
+      const hasInvalidAuthority = authorityUnits.some(
+        (authority) => !authority.isValidAuthority,
       );
-
-      const hasInvalidAuthority = competentAuthorities
-        .concat(executingAuthorities)
-        .some((authority) => !authority.isValidAuthority);
 
       if (hasInvalidAuthority) {
         return { message: INACTIVE_AUTHORITY_ERROR_MESSAGE };

--- a/src/core/domain/ensure-linked-authorities-exist-as-code-list-domain-service.ts
+++ b/src/core/domain/ensure-linked-authorities-exist-as-code-list-domain-service.ts
@@ -5,6 +5,7 @@ import {
 import { BestuurseenheidRegistrationCodeFetcher } from "../port/driven/external/bestuurseenheid-registration-code-fetcher";
 import { Iri } from "./shared/iri";
 import { Logger } from "../../../platform/logger";
+import { WEGWIJS_URL } from "../../../config";
 
 export class EnsureLinkedAuthoritiesExistAsCodeListDomainService {
   private readonly _bestuurseenheidRegistrationCodeFetcher: BestuurseenheidRegistrationCodeFetcher;
@@ -51,7 +52,7 @@ export class EnsureLinkedAuthoritiesExistAsCodeListDomainService {
       CodeSchema.IPDCOrganisaties,
       codeListData.uri,
       codeListData.prefLabel,
-      new Iri("https://wegwijs.vlaanderen.be"),
+      new Iri(WEGWIJS_URL),
     );
   }
 }

--- a/src/core/domain/shared/iri.ts
+++ b/src/core/domain/shared/iri.ts
@@ -14,6 +14,12 @@ export class Iri {
     return this._value;
   }
 
+  get isOvoCodeIri(): boolean {
+    return this.value.startsWith(
+      "https://data.vlaanderen.be/id/organisatie/OVO",
+    );
+  }
+
   toString(): string {
     return this.value;
   }

--- a/src/driven/persistence/code-sparql-repository.ts
+++ b/src/driven/persistence/code-sparql-repository.ts
@@ -3,7 +3,7 @@ import {
   CodeSchema,
 } from "../../core/port/driven/persistence/code-repository";
 import { SparqlQuerying } from "./sparql-querying";
-import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { PREFIX, PUBLIC_GRAPH, WEGWIJS_URL } from "../../../config";
 import { sparqlEscapeString, sparqlEscapeUri, uuid } from "../../../mu-helper";
 import { Iri } from "../../core/domain/shared/iri";
 import { NS } from "./namespaces";
@@ -89,7 +89,7 @@ export class CodeSparqlRepository implements CodeRepository {
                 GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {            
                   ?s a skos:Concept ;
                     skos:inScheme dvcs:IPDCOrganisaties ;
-                    rdfs:seeAlso <https://wegwijs.vlaanderen.be> ;
+                rdfs:seeAlso ${sparqlEscapeUri(WEGWIJS_URL)} ;
                     ?p ?o .
                 }
             }

--- a/test/core/application/validate-instance-for-publish-application-service.it-test.ts
+++ b/test/core/application/validate-instance-for-publish-application-service.it-test.ts
@@ -40,6 +40,8 @@ import {
   aSpatialWithFutureEndDate,
   anExpiredSpatial,
 } from "../domain/spatial-test-builder";
+import { Iri } from "../../../src/core/domain/shared/iri";
+import { CodeSchema } from "../../../src/core/port/driven/persistence/code-repository";
 
 describe("ValidateInstanceForPublishApplicationService", () => {
   describe("validate", () => {
@@ -881,6 +883,58 @@ describe("ValidateInstanceForPublishApplicationService", () => {
         { message: INACTIVE_AUTHORITY_ERROR_MESSAGE },
         { message: EXPIRED_SPATIAL_ERROR_MESSAGE },
       ]);
+    });
+
+    test("no error thrown when a Wegwijs Vlaanderen concept is assigned as competent authority", async () => {
+      const id = uuid();
+      const iri = new Iri(`http://some-iri/${id}`);
+      const prefLabel = "Some concept code";
+      const seeAlso = new Iri("https://wegwijs.vlaanderen.be");
+
+      await codeRepository.save(
+        CodeSchema.IPDCOrganisaties,
+        iri,
+        prefLabel,
+        seeAlso,
+      );
+
+      const bestuurseenheid = aBestuurseenheid().build();
+      const instance = aFullInstance().withCompetentAuthorities([iri]).build();
+      await instanceRepository.save(bestuurseenheid, instance);
+
+      const errorList =
+        await validateInstanceForPublishApplicationService.validate(
+          instance.id,
+          bestuurseenheid,
+        );
+
+      expect(errorList).toEqual([]);
+    });
+
+    test("no error thrown when a Wegwijs Vlaanderen concept is assigned as executing authority", async () => {
+      const id = uuid();
+      const iri = new Iri(`http://some-iri/${id}`);
+      const prefLabel = "Some concept code";
+      const seeAlso = new Iri("https://wegwijs.vlaanderen.be");
+
+      await codeRepository.save(
+        CodeSchema.IPDCOrganisaties,
+        iri,
+        prefLabel,
+        seeAlso,
+      );
+
+      const bestuurseenheid = aBestuurseenheid().build();
+      const instance = aFullInstance().withExecutingAuthorities([iri]).build();
+      await instanceRepository.save(bestuurseenheid, instance);
+
+      const errorList =
+        await validateInstanceForPublishApplicationService.validate(
+          instance.id,
+          bestuurseenheid,
+        );
+
+      expect(errorList).toEqual([]);
     });
   });
 });

--- a/test/core/domain/ensure-linked-authorities-exists-as-code-list-domain-service.it-test.ts
+++ b/test/core/domain/ensure-linked-authorities-exists-as-code-list-domain-service.it-test.ts
@@ -1,6 +1,6 @@
 import { Iri } from "../../../src/core/domain/shared/iri";
 import { EnsureLinkedAuthoritiesExistAsCodeListDomainService } from "../../../src/core/domain/ensure-linked-authorities-exist-as-code-list-domain-service";
-import { PREFIX, PUBLIC_GRAPH } from "../../../config";
+import { PREFIX, PUBLIC_GRAPH, WEGWIJS_URL } from "../../../config";
 import { sparqlEscapeString, sparqlEscapeUri, uuid } from "../../../mu-helper";
 import { NS } from "../../../src/driven/persistence/namespaces";
 import { CodeSchema } from "../../../src/core/port/driven/persistence/code-repository";
@@ -40,7 +40,7 @@ describe("EnsureLinkedAuthoritiesExistAsCodeListDomainService", () => {
         `${sparqlEscapeUri(competentAuthority)} skos:topConceptOf ${sparqlEscapeUri(NS.dvcs(CodeSchema.IPDCOrganisaties).value)}`,
         `${sparqlEscapeUri(competentAuthority)} skos:prefLabel ${sparqlEscapeString("prefLabel")}`,
         `${sparqlEscapeUri(competentAuthority)} mu:uuid ${sparqlEscapeString(uuid())}`,
-        `${sparqlEscapeUri(competentAuthority)} rdfs:seeAlso ${sparqlEscapeUri("https://wegwijs.vlaanderen.be")}`,
+        `${sparqlEscapeUri(competentAuthority)} rdfs:seeAlso ${sparqlEscapeUri(WEGWIJS_URL)}`,
       ],
       [PREFIX.skos, PREFIX.mu, PREFIX.rdfs],
     );

--- a/test/core/domain/iri-test-builder.ts
+++ b/test/core/domain/iri-test-builder.ts
@@ -1,3 +1,4 @@
+import { WEGWIJS_URL } from "../../../config";
 import { Iri } from "../../../src/core/domain/shared/iri";
 
 export function buildConceptSnapshotIri(uniqueId: string): Iri {
@@ -44,6 +45,14 @@ export function buildInstanceSnapshotIri(uniqueId: string): Iri {
   return new Iri(
     `http://data.lblod.info/id/public-service-snapshot/${uniqueId}`,
   );
+}
+
+export function buildOvoCodeIri(uniqueId: string): Iri {
+  return new Iri(`https://data.vlaanderen.be/id/organisatie/OVO${uniqueId}`);
+}
+
+export function buildWegwijsIri(): Iri {
+  return new Iri(WEGWIJS_URL);
 }
 
 export function randomNumber(min: number, max: number): number {

--- a/test/data-integrity-validation/instance-publish-data-integrity.it-test.ts
+++ b/test/data-integrity-validation/instance-publish-data-integrity.it-test.ts
@@ -52,6 +52,7 @@ const validateInstanceForPublishApplicationService =
     instanceRepository,
     bestuurseenheidRepository,
     spatialRepository,
+    codeRepository,
   );
 
 describe("Instance publish validation", () => {


### PR DESCRIPTION
The validation for publishing product instances introduced in #50 is too strict with respect to competent and executing authorities. Specifically, product instances can have competent and/or executing authorities that are not administrative units. Instead these are resources of the type `skos:Concept` and have a URI of the form `https://data.vlaanderen.be/id/organisatie/OVOxxxxxx`.

The initial validation tries only to retrieve administrative unit resources for the specified authority URIs. This fails with a `NotFoundError` when a URI as above is specified, which in turn results in an incorrect error message being shown to the user.

## Proposed solution
This PR extends the validation logic to correctly deal with competent and executing authorities that are not administrative units. To this end the URIs a product instance refers to as its competent and executing authorities are first grouped into two separate sets:
1. URIs of the form `https://data.vlaanderen.be/id/organisatie/OVOxxxxxx`; and
2. URIs with another shape.

For each group a different validation is performed:
1. For the first group, the validation service uses the `CodeRepository` to verify whether that URI exists for a valid resource. If not, an error will be returned to the user.
2. For the second group, the behaviour remains the same as before. In summary, look for an administrative resource with that URI and check its status.


Note: The competent and executing authorities are selected from the same set[^1], and the validation as well as error message is the same. Therefore, I opted to validate them in one go without distinguishing in which field they were entered. This avoids validating the same URI twice when it is both a competent and executing authority. The disadvantage is that more changes will be required if we, for example, want to show different error messages for these cases.

## How to reproduce the bug
1. Log in to LPDC, any organisation should work
2. Create a new product instance via the "+ Product of dienst toevoegen" button in the top-right corner
3. Select a product concept that has non-administrative units as competent and/or executing authority. For example, "Attest van wettelijke samenwoning" and "Aangifte van adreswijziging" link to "Dienst welzijn".
4. Create a new product instance by pressing the "+ Voeg toe" button in the top-right corner
5. Optional: check the competent and/or executing authority fields (*nl. Bevoegde overheid* and *Uitvoerende overheid*) in the instance's properties tab to make sure it contains appropriate values
6. Try to publish the product instance using the "Verzend naar Vlaamse overheid" button in the top-right corner
7. You should receive an error message in the top-right corner saying "*Het product dat je probeert te verzenden, is gelinkt aan een inactief bestuur. Kijk in de tab ‘eigenschappen’ de overheidsorganisatie na.*"

Alternatively, use an existing product instance instead of creating one:
1. Log in to LPDC, any organisation is fine
2. Select an existing product instance. (If you selected an already published product instance, click the "Product opnieuw bewerken" button in the top right hand corner to be able to edit the product instance.)
3. Go to the properties tab and select a non-administrative unit as competent and or executing authority. Some example organisations are "Dienst welzijn", "ACT Vlaams-Brabant", and "Departement Cultuur, Jeugd en Media".
4. Continue with step 6 above.

## How to test validation functionality
Same as the "How to test" section in #50

## Notes
The following query can be used to list all available non-administrative unit authorities:

``` sparql
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

SELECT DISTINCT ?name ?s
WHERE {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s skos:inScheme <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties>;
       skos:prefLabel ?name.
    FILTER (STRSTARTS(STR(?s), "https://data.vlaanderen.be/id/organisatie/OVO"))
  }
}

```

## Related tickets
- LPDC-1344: the bug addressed in this PR
- LPDC-1335: the original validation functionality


[^1]: All resources in the <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties> concept scheme.