### PR TITLE
feat: product instance archival for municipality mergers 2025

### DIFF
--- a/migration-scripts/transfer-instances/archive-instances-script.ts
+++ b/migration-scripts/transfer-instances/archive-instances-script.ts
@@ -172,8 +172,148 @@ type Configuration = {
 };
 
 const archiveConfigurations: Configuration[] = [
+  // Antwerpen (municipality and OCMW): nothing
+  // Borsbeek (municipaity): everything
   {
-    uri: "",
+    uri: "http://data.lblod.info/id/bestuurseenheden/e41ffa04f94bb450a79793020e70d55b5fee5033a5280277998608a9d0913117",
+  },
+
+  // Beveren (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/4f0eb4436c88cf831c35f84e7c34ce32f9ee4e99c5139aff62990e5e531aa1e7",
+  },
+  // Kruibeke (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/6af55cecaea3621f53bb32417a36ed6e3d41b2aa5b9f6d62ab3d80cc8ec11539",
+  },
+  // Zwijndrecht (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/c362abc58ac4579ff417824ce620962ac57bc344b34fe8f51d21b35ef54da36d",
+  },
+
+  // Bilzen-Hoeselt (municipality): selection
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/99da98a7a0087d3429b084ebfc4eb5d488c593790d4d5af7253982a2e21a6a5f",
+    keepMunicipalityMergerInstances: true,
+  },
+  // Hoeselt (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/a3bd0845853278f478f90b14436d3efa99e73249a84d462f0ddc2e5b6e37a156",
+  },
+
+  // Borgloon (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f",
+  },
+  // Tongeren-Borgloon (municipality): selection
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625",
+    keepMunicipalityMergerInstances: true,
+  },
+
+  // De Pinte (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/e39bc997aa6dd9f240277735efd745b6a0422614d2b36cf01825c86b1b91a9ee",
+  },
+  // Nazareth (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/0327a51548f73607f8a5ec11b36711a3c96703686ad93a3d632718c135c295db",
+  },
+
+  // Galmaarden (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/00eb231f51bd6b4f5dcc6536b2d09a174ea8583f5bf28b10bc4fc769a07e511d",
+  },
+  // Gooik (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/c69192b973a3ca11531b9657b3ee20aa6688fa33ea1ef1392310fec751980ab2",
+  },
+  // Herne (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/3eb8c9fae32d02359dcd7b22e2a74e67a5b48388df31ad819c27c688fedd10b0",
+  },
+
+  // Tessenderlo-Ham (municipality): nothing
+  // Tessenderlo (municipalty): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/af8969752f6b28c66b6bc402d7987fa38774901ac72b95c5cb7976570487c3c9",
+  },
+  // Tessenderlo (OCMW): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/fb1be873c4b31e391613dfae8e68edd694b1fdf126eeecb502b1e5cad6f2f682",
+  },
+
+  // Kortessem (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/f6b131de5e40a0dfd4fc93fedf3b95c9bf156ece718b87fe00469dea2564b3fb",
+  },
+  // Hasselt (municipality): selection
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169",
+    keepMunicipalityMergerInstances: true,
+  },
+  // Hasselt (OCMW): selection
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/026509cf3b4eeb7ad88fe57a270060574f60abd1c3524837d36700e40809d210",
+    keepMunicipalityMergerInstances: true,
+  },
+
+  // Lochristi (municipality): selection
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/2ac1bb2a7d7bbd98e2e7a24be2c67e42171788a71c2436a33060626593bb2f78",
+    keepMunicipalityMergerInstances: true,
+  },
+  // Wachtebeke (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/1313d4a58f9ecf52cc7e274e3549a759b35e731973cc9f5e07562e5650f594dd",
+  },
+
+  // Lokeren (municipality): selection
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/cb2a6e0a490ee881ddd0d9ded7f2b3d1dc2df7e57a19d014caac054bfa355f5a",
+    keepMunicipalityMergerInstances: true,
+  },
+  // Lokeren (OCMW): selection
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/323a24f2fe81ee0b6586ec78be36760e478092e07386b2785992ea8b61941833",
+    keepMunicipalityMergerInstances: true,
+  },
+  // Moerbeke (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/c5dbb08e35e2d090a05d119fef4cc161b5ee1f322698cb8ea3c8c6643a521cf2",
+  },
+
+  // Melle (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/c0b6b5cf198cd939251dff8ed052177cfff245074c6b8d43394c8c97f7b6e945",
+  },
+  // Melle (OCMW): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/04895013fe6301f32aa46deae98abfb833a717ece5a33b6c453674c6d0f4cc5e",
+  },
+  // Merelbeke (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/8ef1e4a43efd913e6b09b0ddea344b7b5d723a344ad559389a55ae1ff0bebc8f",
+  },
+
+  // Meulebeke (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515",
+  },
+  // Tielt (municipality): selection
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a",
+    keepMunicipalityMergerInstances: true,
+  },
+
+  // Ruiselede (municipality): everything
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/2564e21e3650f91625189ccb7eb055e47754a0633c54c7582a899171fef60c52",
+  },
+  // Wingene (municipality): selection
+  {
+    uri: "http://data.lblod.info/id/bestuurseenheden/99ed6eee81a7aca47517cbffb46eaba38f3987eeb4ad32c020898644769eb615",
+    keepMunicipalityMergerInstances: true,
   },
 ];
 

--- a/migration-scripts/transfer-instances/archive-instances-script.ts
+++ b/migration-scripts/transfer-instances/archive-instances-script.ts
@@ -25,7 +25,9 @@ async function archiveProductInstances(
   const bestuurseenheid =
     await bestuurseenheidRepository.findById(bestuurseenheidId);
 
-  console.log(`Generating archive migration for ${bestuurseenheid.prefLabel}`);
+  console.log(
+    `Generating archive migration for ${bestuurseenheid.prefLabel} (${bestuurseenheid.classificatieCode})`,
+  );
 
   const domainToQuadsMerger = new DomainToQuadsMapper(
     bestuurseenheid.userGraph(),
@@ -37,7 +39,9 @@ async function archiveProductInstances(
       )
     : await getAllInstanceIdsForBestuurseenheid(bestuurseenheid);
 
-  console.log(`Instances to archive: ${instanceIds.length}`);
+  console.log(
+    `Instances to archive for ${bestuurseenheid.prefLabel} (${bestuurseenheid.classificatieCode}): ${instanceIds.length}`,
+  );
 
   for (const instanceId of instanceIds) {
     const instance = await instanceRepository.findById(
@@ -146,7 +150,7 @@ function createSparql(
 
   const filename = buildFilename(
     "archive-instances",
-    bestuurseenheid.prefLabel,
+    bestuurseenheid.prefLabel + "_" + bestuurseenheid.classificatieCode,
   );
 
   if (deleteTriples.length > 0 || insertTriples.length > 0) {


### PR DESCRIPTION
## Changes
### Configuration for the 2025 municipality mergers
Added the configuration to generate the needed product instance archival migrations for the 2025 municipality mergers. The intended archival is described in the related ticket. The following table (slightly modified from the ticket) summaries the intended result.

| Organisation name | Product instances to archive |
|-------------------|------------------------------|
| Antwerpen         | None                         |
| Borsbeek          | All                          |
|                   |                              |
| Beveren           | All                          |
| Kruibeke          | All                          |
| Zwijndrecht       | All                          |
|                   |                              |
| Bilzen-Hoeselt    | Non-merger instances         |
| Hoeselt           | All                          |
|                   |                              |
| Borgloon          | All                          |
| Tongeren-Borgloon | Non-merger instances         |
|                   |                              |
| De Pinte          | All                          |
| Nazareth          | All                          |
|                   |                              |
| Galmaarden        | All                          |
| Gooik             | All                          |
| Herne             | All                          |
|                   |                              |
| Tessenderlo-Ham   | None                         |
| Tessenderlo       | All                          |
| OCMW Tessenderlo  | All                          |
|                   |                              |
| Kortessem         | All                          |
| Hasselt           | Non-merger instances         |
| OCMW Hasselt      | Non-merger instances         |
|                   |                              |
| Lochristi         | Non-merger instances         |
| Wachtebeke        | All                          |
|                   |                              |
| Lokeren           | Non-merger instances         |
| OCMW Lokeren      | Non-merger instances         |
| Moerbeke          | All                          |
|                   |                              |
| Melle             | All                          |
| OCMW Melle        | All                          |
| Merelbeke         | All                          |
|                   |                              |
| Meulebeke         | All                          |
| Tielt             | Non-merger instances         |
|                   |                              |
| Ruiselede         | All                          |
| Wingene           | Non-merger instances         |

Explanation for the table:
- Unless specified otherwise the organisation name means the municipality with that name
- *Non-merger instances* means archive only those produce instances that do **not** have merger label. This label is represented in the data by the `lpdcExt:forMunicipalityMerger` predicate with a boolean as object. In the frontend, product instances with this label have a green pill with the text "Fusie" in their name column.

### Bugfix
The migrations generated by the initial version of the script put all triples to remove in a single `DELETE` query per organisation. In other words, each generated migration contained exactly one `DELETE` query that deletes the triples for all relevant product instances. In situations where there are many product instances[^1] this risks virtuoso running out of memory while parsing the querying, thereby crashing the migrations service.

To prevent such errors from happening, the `archive-instances-script.ts` was modified to write a separate `DELETE` query for each product instance that must be archived. Thus each generated migration should now have as many `DELETE` queries as there are product instances to delete. At least for the organisations relevant for this PR this resolves the out of memory issue when executing the migrations.

## How to test
### Obtaining the migrations
To generate the archival migrations, consult the script's [README](https://github.com/lblod/lpdc-management-service/blob/chore/generate-product-instance-archival-migrations/migration-scripts/transfer-instances/readme.md) on how to use the generation script. Note, only PROD data is guaranteed to representative for the situation at hand, the data on ACC/TEST/DEV is not likely representative. After generation move the migrations to the `config/migrations/local/` folder for your local backend.

Alternatively, use the example migrations added in [#46](https://github.com/lblod/app-lpdc-digitaal-loket/pull/46). These are generated against production data and should be representative of the migrations that will be executed locally on PROD. Minor differences between the examples and the final migrations may occur due to actions by the users. For example, adding or removing product instances or (un)setting the merger label for product instances.

### Testing the migrations
- Run the migrations by restarting the migrations service. It takes a while for all migrations to execute, keep an eye on the service logs to know when they are done.
- Once the migrations have run. Inspect the organisations in the above table via the frontend, each organisation with
    - `All` should have no product instances anymore
    - `None` should be unchanged
    - `Non-merger instances` should only have product instances with the merger label

## Related tickets
- LPDC-1317


[^2]: On my local development stack the cutoff was around 60 product instances, which roughly corresponds to 4000 triples for the cases in this PR.