### PR TITLE
chore: fix failing test

### DIFF
--- a/test/core/domain/bring-instance-up-to-date-with-concept-snapshot-version-domain-service.it-test.ts
+++ b/test/core/domain/bring-instance-up-to-date-with-concept-snapshot-version-domain-service.it-test.ts
@@ -462,8 +462,9 @@ describe("Bring instance up to date with concept snapshot version domain service
           ConceptSnapshotTestBuilder.COMPETENT_AUTHORITY_LEVELS,
         )
         .withCompetentAuthorities([
-          BestuurseenheidTestBuilder.OUD_HEVERLEE_IRI,
-          BestuurseenheidTestBuilder.ASSENEDE_IRI,
+          BestuurseenheidTestBuilder.PEPINGEN_IRI,
+          BestuurseenheidTestBuilder.HOUTHALEN_HELCHTEREN_IRI,
+          BestuurseenheidTestBuilder.BORGLOON_IRI,
         ])
         .withExecutingAuthorityLevels(
           ConceptSnapshotTestBuilder.EXECUTING_AUTHORITY_LEVELS,


### PR DESCRIPTION
The behaviour of the tested function was slightly changed in #45. Since then
competent authorities are only taken from the concept if the instance to update
does **not** have local as competent authority level. The test still assumed the
old behaviour in which competent authorities are always taken from the concept.

This fixes the test by correcting the `expectedInstance` to have the same
competent authorities of the updated instance. In the test at hand the competent
authorities of the instance are not changed during update since is has a local
competent authority level.

Fixing this issue makes the test suite more usable again and allows the jobs in
the woodpecker pipeline to succeed again.