### PR TITLE
feat: additional validations for URIs contained in product instance snapshots

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -167,6 +167,8 @@ const instanceSnapshotToInstanceMergerDomainService =
     linkedAuthorityCodeListDomainService,
     instanceSnapshotProcessingAuthorizationRepository,
     bestuurseenheidRepository,
+    spatialRepository,
+    codeRepository,
   );
 
 const instanceSnapshotProcessorApplicationService =

--- a/src/core/domain/bestuurseenheid.ts
+++ b/src/core/domain/bestuurseenheid.ts
@@ -58,6 +58,10 @@ export class Bestuurseenheid {
     return this._status;
   }
 
+  get isActive() {
+    return this.status === BestuurseenheidStatusCode.ACTIVE;
+  }
+
   get spatials(): Iri[] {
     return [...this._spatials];
   }

--- a/src/core/domain/ensure-linked-authorities-exist-as-code-list-domain-service.ts
+++ b/src/core/domain/ensure-linked-authorities-exist-as-code-list-domain-service.ts
@@ -7,6 +7,11 @@ import { Iri } from "./shared/iri";
 import { Logger } from "../../../platform/logger";
 import { WEGWIJS_URL } from "../../../config";
 
+type CodeListData = {
+  uri?: Iri;
+  prefLabel?: string;
+};
+
 export class EnsureLinkedAuthoritiesExistAsCodeListDomainService {
   private readonly _bestuurseenheidRegistrationCodeFetcher: BestuurseenheidRegistrationCodeFetcher;
   private readonly _codeRepository: CodeRepository;
@@ -23,6 +28,21 @@ export class EnsureLinkedAuthoritiesExistAsCodeListDomainService {
     this._bestuurseenheidRegistrationCodeFetcher =
       bestuurseenheidRegistrationCodeFetcher;
     this._logger = logger ?? this._logger;
+  }
+
+  async getLinkedAuthority(iri: Iri) {
+    return await this._bestuurseenheidRegistrationCodeFetcher.fetchOrgRegistryCodelistEntry(
+      iri.value,
+    );
+  }
+
+  async addAuthoritiesToCodeList(authorities: CodeListData[]) {
+    authorities
+      .filter(
+        (authority) =>
+          authority.uri !== undefined && authority.prefLabel !== undefined,
+      )
+      .forEach(async (authority) => await this.insertCodeListData(authority));
   }
 
   async ensureLinkedAuthoritiesExistAsCodeList(
@@ -44,10 +64,7 @@ export class EnsureLinkedAuthoritiesExistAsCodeListDomainService {
     }
   }
 
-  private async insertCodeListData(codeListData: {
-    uri?: Iri;
-    prefLabel?: string;
-  }): Promise<void> {
+  private async insertCodeListData(codeListData: CodeListData): Promise<void> {
     return this._codeRepository.save(
       CodeSchema.IPDCOrganisaties,
       codeListData.uri,

--- a/src/core/domain/shared/iri.ts
+++ b/src/core/domain/shared/iri.ts
@@ -1,5 +1,16 @@
 import { Invariant } from "./invariant";
 
+const ovoPattern =
+  /^https:\/\/data\.vlaanderen\.be\/id\/organisatie\/OVO[0-9]{6}$/;
+
+// NOTE (20/03/2025): require at least 12 characters in the UUID for an
+// administrative unit. This is a bit arbitrary but allows to exclude URIs
+// that contain too short UUIDs such as a OVO-code instead of an actual
+// UUID. At the time of writing the shortest UUID in OP, which is master of
+// this data, in 24 characters.
+const unitPattern =
+  /^http:\/\/data\.lblod\.info\/id\/bestuurseenheden\/[0-9a-zA-Z-]{12,}$/;
+
 export class Iri {
   constructor(private _value: string) {
     const invariant = Invariant.require(_value, "iri");
@@ -18,6 +29,16 @@ export class Iri {
     return this.value.startsWith(
       "https://data.vlaanderen.be/id/organisatie/OVO",
     );
+  }
+
+  get isAdministrativeUnitIri(): boolean {
+    return this._value.startsWith(
+      "http://data.lblod.info/id/bestuurseenheden/",
+    );
+  }
+
+  get isValidAuthorityIri(): boolean {
+    return ovoPattern.test(this._value) || unitPattern.test(this._value);
   }
 
   toString(): string {

--- a/src/core/domain/shared/lpdc-error.ts
+++ b/src/core/domain/shared/lpdc-error.ts
@@ -19,6 +19,14 @@ export class InvariantError extends LpdcError {
   }
 }
 
+export class InstanceSnapshotValidationError extends LpdcError {
+  constructor(
+    message = "De gegevens in de productinstantie snapshot zijn ongeldig.",
+  ) {
+    super(message);
+  }
+}
+
 export class NotFoundError extends LpdcError {
   constructor(
     message: string = "De opgevraagde gegevens werden niet gevonden.",

--- a/src/core/port/driven/persistence/bestuurseenheid-repository.ts
+++ b/src/core/port/driven/persistence/bestuurseenheid-repository.ts
@@ -3,4 +3,5 @@ import { Bestuurseenheid } from "../../../domain/bestuurseenheid";
 
 export interface BestuurseenheidRepository {
   findById(id: Iri): Promise<Bestuurseenheid>;
+  exists(id: Iri): Promise<boolean>;
 }

--- a/src/driven/persistence/bestuurseenheid-sparql-repository.ts
+++ b/src/driven/persistence/bestuurseenheid-sparql-repository.ts
@@ -80,6 +80,19 @@ export class BestuurseenheidSparqlRepository
     );
   }
 
+  async exists(id: Iri) {
+    const query = `
+      ${PREFIX.besluit}
+
+      ASK {
+        GRAPH <http://mu.semte.ch/graphs/public> {
+          ${sparqlEscapeUri(id)} a besluit:Bestuurseenheid.
+        }
+      }`;
+
+    return this.querying.ask(query);
+  }
+
   mapBestuurseenheidClassificatieUriToCode(
     classificatieCodeUri: BestuurseenheidClassificatieCodeUri | undefined,
   ): BestuurseenheidClassificatieCode | undefined {

--- a/src/driven/persistence/code-sparql-repository.ts
+++ b/src/driven/persistence/code-sparql-repository.ts
@@ -19,7 +19,7 @@ export class CodeSparqlRepository implements CodeRepository {
   async exists(schema: CodeSchema, id: Iri): Promise<boolean> {
     const query = `
         ${PREFIX.skos}
-        
+
         ASK {
             GRAPH ?g {
                 ${sparqlEscapeUri(id)} a skos:Concept;
@@ -67,10 +67,10 @@ export class CodeSparqlRepository implements CodeRepository {
                 GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {
                   ?bestuurseenheid a besluit:Bestuurseenheid ;
                     skos:prefLabel ?bestuurseenheidLabel .
-            
+
                   ?bestuurseenheid besluit:classificatie ?bestuurseenheidClassificatie .
                   ?bestuurseenheidClassificatie skos:prefLabel ?bestuurseenheidClassificatieLabel .
-            
+
                   BIND(CONCAT(?bestuurseenheidLabel, " (", ?bestuurseenheidClassificatieLabel, ")") as ?newLabel)
                }
             }
@@ -80,13 +80,13 @@ export class CodeSparqlRepository implements CodeRepository {
             ${PREFIX.skos}
             ${PREFIX.dvcs}
             ${PREFIX.rdfs}
-        
+
             CONSTRUCT {
               ?s ?p ?o ;
                 skos:inScheme <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties/tailored> .
             }
             WHERE {
-                GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {            
+                GRAPH ${sparqlEscapeUri(PUBLIC_GRAPH)} {
                   ?s a skos:Concept ;
                     skos:inScheme dvcs:IPDCOrganisaties ;
                 rdfs:seeAlso ${sparqlEscapeUri(WEGWIJS_URL)} ;

--- a/test/core/application/instance-snapshot-processor-application-service.it-test.ts
+++ b/test/core/application/instance-snapshot-processor-application-service.it-test.ts
@@ -21,6 +21,7 @@ import { InstanceBuilder } from "../../../src/core/domain/instance";
 import { VersionedLdesSnapshotSparqlRepository } from "../../../src/driven/persistence/versioned-ldes-snapshot-sparql-repository";
 import { InstanceSparqlRepository } from "../../../src/driven/persistence/instance-sparql-repository";
 import spyOn = jest.spyOn;
+import { SpatialSparqlRepository } from "../../../src/driven/persistence/spatial-sparql-repository";
 
 describe("InstanceSnapshotProcessorApplicationService", () => {
   beforeEach(async () => {
@@ -37,6 +38,9 @@ describe("InstanceSnapshotProcessorApplicationService", () => {
   const conceptRepository = new ConceptSparqlRepository(TEST_SPARQL_ENDPOINT);
   const conceptDisplayConfigurationRepository =
     new ConceptDisplayConfigurationSparqlTestRepository(TEST_SPARQL_ENDPOINT);
+
+  const spatialRepository = new SpatialSparqlRepository(TEST_SPARQL_ENDPOINT);
+
   const deleteInstanceDomainService = new DeleteInstanceDomainService(
     instanceRepository,
     conceptDisplayConfigurationRepository,
@@ -66,6 +70,8 @@ describe("InstanceSnapshotProcessorApplicationService", () => {
       linkedAuthoritiesDomainService,
       instanceSnapshotProcessingAuthorizationRepository,
       bestuurseenheidRepository,
+      spatialRepository,
+      codeRepository,
     );
   const versionedLdesSnapshotRepository =
     new VersionedLdesSnapshotSparqlRepository(TEST_SPARQL_ENDPOINT);

--- a/test/core/domain/ensure-linked-authorities-exists-as-code-list-domain-service.it-test.ts
+++ b/test/core/domain/ensure-linked-authorities-exists-as-code-list-domain-service.it-test.ts
@@ -4,7 +4,7 @@ import { PREFIX, PUBLIC_GRAPH, WEGWIJS_URL } from "../../../config";
 import { sparqlEscapeString, sparqlEscapeUri, uuid } from "../../../mu-helper";
 import { NS } from "../../../src/driven/persistence/namespaces";
 import { CodeSchema } from "../../../src/core/port/driven/persistence/code-repository";
-import { buildBestuurseenheidIri } from "./iri-test-builder";
+import { buildBestuurseenheidIri, buildOvoCodeIri } from "./iri-test-builder";
 import { CodeSparqlRepository } from "../../../src/driven/persistence/code-sparql-repository";
 import { TEST_SPARQL_ENDPOINT } from "../../test.config";
 import { DirectDatabaseAccess } from "../../driven/persistence/direct-database-access";
@@ -22,45 +22,178 @@ describe("EnsureLinkedAuthoritiesExistAsCodeListDomainService", () => {
       ),
   };
   const codeRepository = new CodeSparqlRepository(TEST_SPARQL_ENDPOINT);
-  const ensureLinkedAuthoritiesExistAsCodeListDomainService =
-    new EnsureLinkedAuthoritiesExistAsCodeListDomainService(
-      bestuurseenheidRegistrationCodeFetcher,
-      codeRepository,
-    );
+  const testedService = new EnsureLinkedAuthoritiesExistAsCodeListDomainService(
+    bestuurseenheidRegistrationCodeFetcher,
+    codeRepository,
+  );
 
-  test("insert codeList if not exists", async () => {
-    const competentAuthority = buildBestuurseenheidIri(uuid());
+  const knownAuthority = buildBestuurseenheidIri("an-administrative-unit");
 
+  beforeEach(async () => {
     await directDatabaseAccess.insertData(
       PUBLIC_GRAPH,
       [
-        `${sparqlEscapeUri(NS.dvcs(CodeSchema.IPDCOrganisaties).value)} a skos:ConceptScheme`,
-        `${sparqlEscapeUri(competentAuthority)} a skos:Concept`,
-        `${sparqlEscapeUri(competentAuthority)} skos:inScheme ${sparqlEscapeUri(NS.dvcs(CodeSchema.IPDCOrganisaties).value)}`,
-        `${sparqlEscapeUri(competentAuthority)} skos:topConceptOf ${sparqlEscapeUri(NS.dvcs(CodeSchema.IPDCOrganisaties).value)}`,
-        `${sparqlEscapeUri(competentAuthority)} skos:prefLabel ${sparqlEscapeString("prefLabel")}`,
-        `${sparqlEscapeUri(competentAuthority)} mu:uuid ${sparqlEscapeString(uuid())}`,
-        `${sparqlEscapeUri(competentAuthority)} rdfs:seeAlso ${sparqlEscapeUri(WEGWIJS_URL)}`,
+        `${sparqlEscapeUri(knownAuthority)} a skos:Concept`,
+        `${sparqlEscapeUri(knownAuthority)} skos:inScheme ${sparqlEscapeUri(NS.dvcs(CodeSchema.IPDCOrganisaties).value)}`,
+        `${sparqlEscapeUri(knownAuthority)} skos:topConceptOf ${sparqlEscapeUri(NS.dvcs(CodeSchema.IPDCOrganisaties).value)}`,
+        `${sparqlEscapeUri(knownAuthority)} skos:prefLabel ${sparqlEscapeString("prefLabel")}`,
+        `${sparqlEscapeUri(knownAuthority)} mu:uuid ${sparqlEscapeString(uuid())}`,
+        `${sparqlEscapeUri(knownAuthority)} rdfs:seeAlso ${sparqlEscapeUri(WEGWIJS_URL)}`,
       ],
       [PREFIX.skos, PREFIX.mu, PREFIX.rdfs],
     );
+  });
 
-    const executingAuthorityWithoutCodeList = buildBestuurseenheidIri(uuid());
+  afterEach(async () => {
+    directDatabaseAccess.clearGraph(PUBLIC_GRAPH);
+  });
 
-    await ensureLinkedAuthoritiesExistAsCodeListDomainService.ensureLinkedAuthoritiesExistAsCodeList(
-      [competentAuthority, executingAuthorityWithoutCodeList],
-    );
+  describe("getLinkedAuthority", () => {
+    test("it returns an object with an IRI and label for a match", async () => {
+      const iri = buildOvoCodeIri("123456");
+      const result = await testedService.getLinkedAuthority(iri);
 
-    const createdCompetentAuthorityCode = await codeRepository.exists(
-      CodeSchema.IPDCOrganisaties,
-      competentAuthority,
-    );
-    expect(createdCompetentAuthorityCode).toBeTruthy();
+      expect(result).toEqual({
+        uri: iri.value,
+        prefLabel: `preferred label for: ${iri}`,
+      });
+    });
+  });
 
-    const createdExecutingAuthorityCode = await codeRepository.exists(
-      CodeSchema.IPDCOrganisaties,
-      executingAuthorityWithoutCodeList,
-    );
-    expect(createdExecutingAuthorityCode).toBeTruthy();
+  describe("addAuthoritiesToCodeList", () => {
+    test("it inserts an unknown authority to the code list", async () => {
+      const unknownAuthority = buildBestuurseenheidIri("an-unknown-authority");
+
+      const before = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        unknownAuthority,
+      );
+      expect(before).toBeFalse;
+
+      await testedService.addAuthoritiesToCodeList([
+        { uri: unknownAuthority, prefLabel: "unknown-authority" },
+      ]);
+
+      const after = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        unknownAuthority,
+      );
+      expect(after).toBeTrue;
+    });
+
+    test("it does not change already existing authorities", async () => {
+      const before = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        knownAuthority,
+      );
+      expect(before).toBeTrue();
+
+      await testedService.addAuthoritiesToCodeList([
+        { uri: knownAuthority, prefLabel: "known-authority" },
+      ]);
+
+      const after = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        knownAuthority,
+      );
+      expect(after).toBeTrue();
+    });
+
+    test("it does not add an authority without a URI", async () => {
+      const unknownAuthority = buildBestuurseenheidIri("an-unknown-authority");
+      await testedService.addAuthoritiesToCodeList([
+        { prefLabel: "authority-without-uri" },
+      ]);
+
+      const after = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        unknownAuthority,
+      );
+      expect(after).toBeFalse();
+    });
+
+    test("it does not add an authority without a preflabel", async () => {
+      const unknownAuthority = buildBestuurseenheidIri("an-unknown-authority");
+      await testedService.addAuthoritiesToCodeList([{ uri: unknownAuthority }]);
+
+      const after = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        unknownAuthority,
+      );
+      expect(after).toBeFalse();
+    });
+  });
+
+  describe("ensureLinkedAuthoritiesExistsAsCodeList", () => {
+    test("it inserts an unknown authority to the code list", async () => {
+      const unknownAuthority = buildBestuurseenheidIri(uuid());
+
+      const before = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        unknownAuthority,
+      );
+      expect(before).toBeFalse;
+
+      await testedService.ensureLinkedAuthoritiesExistAsCodeList([
+        unknownAuthority,
+      ]);
+
+      const after = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        unknownAuthority,
+      );
+      expect(after).toBeTrue;
+    });
+
+    test("it does not change already existing authorities", async () => {
+      const before = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        knownAuthority,
+      );
+      expect(before).toBeTrue();
+
+      await testedService.ensureLinkedAuthoritiesExistAsCodeList([
+        knownAuthority,
+      ]);
+
+      const after = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        knownAuthority,
+      );
+      expect(after).toBeTrue();
+    });
+
+    test("it adds unknown authorities to the code list", async () => {
+      const unknownAuthority = buildBestuurseenheidIri(uuid());
+
+      const unknownBefore = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        unknownAuthority,
+      );
+      expect(unknownBefore).toBeFalse;
+
+      const knownBefore = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        knownAuthority,
+      );
+      expect(knownBefore).toBeTrue();
+
+      await testedService.ensureLinkedAuthoritiesExistAsCodeList([
+        knownAuthority,
+        unknownAuthority,
+      ]);
+
+      const unknownAfter = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        unknownAuthority,
+      );
+      expect(unknownAfter).toBeTrue;
+
+      const knownAfter = await codeRepository.exists(
+        CodeSchema.IPDCOrganisaties,
+        knownAuthority,
+      );
+      expect(knownAfter).toBeTrue();
+    });
   });
 });

--- a/test/core/domain/instance-snapshot-test-builder.ts
+++ b/test/core/domain/instance-snapshot-test-builder.ts
@@ -23,7 +23,6 @@ import {
   buildBestuurseenheidIri,
   buildConceptIri,
   buildInstanceSnapshotIri,
-  buildNutsCodeIri,
 } from "./iri-test-builder";
 import { BestuurseenheidTestBuilder } from "./bestuurseenheid-test-builder";
 import {
@@ -60,6 +59,7 @@ import {
   anotherFullLegalResourceForInstanceSnapshot,
 } from "./legal-resource-test-builder";
 import { InstanceBuilder } from "../../../src/core/domain/instance";
+import { SpatialTestBuilder } from "./spatial-test-builder";
 
 export function aMinimalInstanceSnapshot(): InstanceSnapshotTestBuilder {
   const uniqueId = uuid();
@@ -213,9 +213,9 @@ export class InstanceSnapshotTestBuilder {
     CompetentAuthorityLevelType.VLAAMS,
   ];
   public static readonly COMPETENT_AUTHORITIES = [
-    BestuurseenheidTestBuilder.ASSENEDE_IRI,
     BestuurseenheidTestBuilder.PEPINGEN_IRI,
     BestuurseenheidTestBuilder.HOUTHALEN_HELCHTEREN_IRI,
+    BestuurseenheidTestBuilder.BORGLOON_IRI,
   ];
   public static readonly EXECUTING_AUTHORITY_LEVELS = [
     ExecutingAuthorityLevelType.DERDEN,
@@ -223,7 +223,7 @@ export class InstanceSnapshotTestBuilder {
     ExecutingAuthorityLevelType.FEDERAAL,
   ];
   public static readonly EXECUTING_AUTHORITIES = [
-    BestuurseenheidTestBuilder.BORGLOON_IRI,
+    BestuurseenheidTestBuilder.PEPINGEN_IRI,
     BestuurseenheidTestBuilder.OUD_HEVERLEE_IRI,
   ];
 
@@ -250,9 +250,8 @@ export class InstanceSnapshotTestBuilder {
   ];
 
   public static readonly SPATIALS = [
-    buildNutsCodeIri(45700),
-    buildNutsCodeIri(52000),
-    buildNutsCodeIri(98786),
+    SpatialTestBuilder.PEPINGEN_SPATIAL_IRI,
+    SpatialTestBuilder.OUD_HEVERLEE_SPATIAL_IRI,
   ];
 
   public static readonly LEGAL_RESOURCES = [

--- a/test/core/domain/shared/iri.unit-test.ts
+++ b/test/core/domain/shared/iri.unit-test.ts
@@ -33,3 +33,54 @@ describe("constructing", () => {
     expect(iri.value).toEqual("http://some-value");
   });
 });
+
+describe("isValidAuthorityIri", () => {
+  test("it should return true for a valid OVO code IRI", () => {
+    const iri = new Iri("https://data.vlaanderen.be/id/organisatie/OVO123456");
+    expect(iri.isValidAuthorityIri).toBeTrue();
+  });
+
+  test("it should return false for an invalid OVO code URLs", () => {
+    let iri = new Iri("https://data.be/id/organisatie/OVO123456");
+    expect(iri.isValidAuthorityIri).toBeFalse();
+
+    iri = new Iri("https://data,vlaanderen,be/id/organisatie/OVO123456");
+    expect(iri.isValidAuthorityIri).toBeFalse();
+  });
+
+  test("it should return true for a valid administrative unit IRI", () => {
+    const iri = new Iri(
+      "http://data.lblod.info/id/bestuurseenheden/09f5b10fbd078fcb1e0e4910d32e47146a5eb31d8138dcbaec798309e64dd059",
+    );
+    expect(iri.isValidAuthorityIri).toBeTrue();
+  });
+
+  test("it should return false for a invalid administrative unit URLs", () => {
+    let iri = new Iri(
+      "http://data/id/bestuurseenheden/09f5b10fbd078fcb1e0e4910d32e47146a5eb31d8138dcbaec798309e64dd059",
+    );
+    expect(iri.isValidAuthorityIri).toBeFalse();
+
+    iri = new Iri(
+      "http://data!lblod+info/id/bestuurseenheden/09f5b10fbd078fcb1e0e4910d32e47146a5eb31d8138dcbaec798309e64dd059",
+    );
+    expect(iri.isValidAuthorityIri).toBeFalse();
+  });
+
+  test("it should return false for a administrative unit IRI with too short of an UUID", () => {
+    const iri = new Iri("http://data.lblod.info/id/bestuurseenheden/OVO002949");
+    expect(iri.isValidAuthorityIri).toBeFalse();
+  });
+
+  test("it should return false for an OVO code IRI with too few digits", () => {
+    const iri = new Iri("https://data.vlaanderen.be/id/organisatie/OVO12");
+    expect(iri.isValidAuthorityIri).toBeFalse();
+  });
+
+  test("it should return false for an OVO code IRI with too many digits", () => {
+    const iri = new Iri(
+      "https://data.vlaanderen.be/id/organisatie/OVO122456789",
+    );
+    expect(iri.isValidAuthorityIri).toBeFalse();
+  });
+});

--- a/test/driven/external/bestuurseenheid-registration-code-through-subject-page-or-api-fetcher.it-test.ts
+++ b/test/driven/external/bestuurseenheid-registration-code-through-subject-page-or-api-fetcher.it-test.ts
@@ -1,0 +1,46 @@
+import { BestuurseenheidRegistrationCodeThroughSubjectPageOrApiFetcher } from "../../../src/driven/external/bestuurseenheid-registration-code-through-subject-page-or-api-fetcher";
+import {
+  buildBestuurseenheidIri,
+  buildOvoCodeIri,
+} from "../../core/domain/iri-test-builder";
+
+describe("BestuurseenheidRegistrationCodeThroughSubjectPageOrApiFetcher", () => {
+  test("it should return a preflabel for an existing administrative unit", async () => {
+    const uriString = buildBestuurseenheidIri(
+      "09f5b10fbd078fcb1e0e4910d32e47146a5eb31d8138dcbaec798309e64dd059",
+    ).value;
+    const fetcher =
+      new BestuurseenheidRegistrationCodeThroughSubjectPageOrApiFetcher();
+    const result = await fetcher.fetchOrgRegistryCodelistEntry(uriString);
+
+    expect(result.prefLabel).toEqual("Genk");
+  });
+
+  test("it should return an empty result for a non-existing administrative unit", async () => {
+    const uriString = buildBestuurseenheidIri(
+      "an-administrative-unit-that-does-not-exist",
+    ).value;
+    const fetcher =
+      new BestuurseenheidRegistrationCodeThroughSubjectPageOrApiFetcher();
+    const result = await fetcher.fetchOrgRegistryCodelistEntry(uriString);
+    expect(result).toBeUndefined;
+  });
+
+  test("it should return a preflabel for an existing OVO code", async () => {
+    const uriString = buildOvoCodeIri("002949").value;
+    const fetcher =
+      new BestuurseenheidRegistrationCodeThroughSubjectPageOrApiFetcher();
+    const result = await fetcher.fetchOrgRegistryCodelistEntry(uriString);
+
+    expect(result.prefLabel).toEqual("agentschap Digitaal Vlaanderen");
+  });
+
+  test("it should return an empty result for a invalid OVO code", async () => {
+    const uriString = buildOvoCodeIri("00").value;
+    const fetcher =
+      new BestuurseenheidRegistrationCodeThroughSubjectPageOrApiFetcher();
+    const result = await fetcher.fetchOrgRegistryCodelistEntry(uriString);
+
+    expect(result).toBeUndefined;
+  });
+});

--- a/test/driven/persistence/bestuurseenheid-repository.it-test.ts
+++ b/test/driven/persistence/bestuurseenheid-repository.it-test.ts
@@ -79,6 +79,23 @@ describe("BestuurseenheidRepository", () => {
     });
   });
 
+  describe("exists", () => {
+    test("it returns true when an administrative unit exists for the specified URI", async function () {
+      const unit = aBestuurseenheid().build();
+      await repository.save(unit);
+
+      const result = await repository.exists(unit.id);
+      expect(result).toBeTrue();
+    });
+
+    test("it returns false when an administrative unit exists for the specified URI", async function () {
+      const unit = aBestuurseenheid().build();
+
+      const result = await repository.exists(unit.id);
+      expect(result).toBeFalse();
+    });
+  });
+
   describe("Verify ontology and mapping", () => {
     test("Verify mappings", async () => {
       const bestuurseenheidUuid = uuid();

--- a/test/driven/persistence/instance-snapshot-repository.it-test.ts
+++ b/test/driven/persistence/instance-snapshot-repository.it-test.ts
@@ -297,7 +297,6 @@ describe("InstanceSnapshotRepository", () => {
         `${sparqlEscapeUri(instanceSnapshotId)} <http://www.w3.org/ns/prov#generatedAtTime> """${InstanceSnapshotTestBuilder.GENERATED_AT_TIME.value}"""^^<http://www.w3.org/2001/XMLSchema#dateTime>`,
         `${sparqlEscapeUri(instanceSnapshotId)} <http://purl.org/dc/terms/spatial> ${sparqlEscapeUri(InstanceSnapshotTestBuilder.SPATIALS[0].value)}`,
         `${sparqlEscapeUri(instanceSnapshotId)} <http://purl.org/dc/terms/spatial> ${sparqlEscapeUri(InstanceSnapshotTestBuilder.SPATIALS[1].value)}`,
-        `${sparqlEscapeUri(instanceSnapshotId)} <http://purl.org/dc/terms/spatial> ${sparqlEscapeUri(InstanceSnapshotTestBuilder.SPATIALS[2].value)}`,
 
         `${sparqlEscapeUri(instanceSnapshotId)} <http://data.europa.eu/m8g/hasLegalResource> ${sparqlEscapeUri(InstanceSnapshotTestBuilder.LEGAL_RESOURCES[0].id)}`,
         `<${InstanceSnapshotTestBuilder.LEGAL_RESOURCES[0].id}> a <http://data.europa.eu/eli/ontology#LegalResource>`,


### PR DESCRIPTION
## Context
More external entities are starting to integrate with LPDC by sending product instance snapshots via LDES. We want to ensure a certain level of data quality of the received snapshots before processing them and sending them to IPDC.

## Proposed solution
Validate any received snapshots as part of processing them upon arrival at LPDC. Only snapshots that pass all validations will be converted to an actual product instance. More specifically, we add validations for the URIs linking a snapshot to other resources.

- The administrative unit that created the snapshot must exist in LPDC and may not have the status inactive.
- If a snapshot is linked to a concept, this concept must be an existing concept in LPDC.
- As geographical area(s), a snapshot may only link to existing and not expired spatials.
- For the linked competent and executing authorities:
  + Each URI must have as format: `http://data.lblod.info/id/bestuurseenheden/UUID` or `https://data.vlaanderen.be/id/organisatie/OVOnnnnnn`, other formats are not allowed.
  + If the authority is known in LPDC and it is an administrative unit[^1], it must *not* have the status inactive.
  + If an authorities is not (yet) known in LPDC, an external API will be used to confirm corresponds to an actual existing organisation.[^2] If so, the authority is added to the `IPDCOrganisaties` code list for future reference.

## How to test
The tests added as part of this PR can be executed to see whether the added validations work.[^3]

If you want to test more interactively you can modify snapshots already in your local stack. To this end, find a suitable product instance snapshot and modify according to what validation you want to test. Make sure to remove any processing marker linked to the modified snapshot, otherwise it will not be picked up again for processing. You can inspect the logs of the management service to see how it processes the modified snapshot. Note, it might take a minute or so before the processing job is triggered.

For example, the following query updates a snapshot to link to an invalid spatial:

```sparql
PREFIX dcterms: <http://purl.org/dc/terms/>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

DELETE {
  GRAPH <http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/gent> {
    ?snapshot dcterms:spatial ?spatial.
    ?marker ?p ?o.
  }
} INSERT {
  GRAPH <http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/gent> {
    ?snapshot dcterms:spatial <http://data.europa.eu/nuts/code/BE23444021>
  }
} WHERE {
  GRAPH <http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/gent> {
    ?snapshot dcterms:spatial ?spatial.
    ?marker ext:processedSnapshot ?snapshot;
            ?p ?o.
  }
  VALUES ?snapshot {
    <https://stad.gent/id/product/82b3db4c-10b2-ea11-a853-005056a8c14b/2025-02-19T10:25:11.366692879>
  }
}
```

## Related tickets
- LPDC-1301
- LPDC-1260: concrete example of where an integrating party sent product instance snapshots with an incorrect authority URI


[^1]: An administrative unit is identified by a URI with as format: `http://data.lblod.info/id/bestuurseenheden/UUID`
[^2]: For administrative unit authorities, Centrale Vindplaats would be used to confirm whether an authority exists. But while implementing the functionality in this PR it was discovered that that functionality does not work (anymore). This was discussed with business and it was decided to leave it as such for now because (1) this particular functionality is rarely used, if at all so far, and (2) the "correct" solution here would be to sync LPDC with OP so that LPDC always has all administrative units.
[^3]: When running the whole test suite several tests will fail consistently. These tests concern the interaction with IPDC, which due to changes on the side op IPDC do not correctly work anymore (see LPDC-1396 for more details). Furthermore, one of the newly added tests will also fail, this is due to the broken functionality explained above.