### PR TITLE
fix: replace NUTS URI placeholder in concept characteristics form

### DIFF
--- a/src/driven/persistence/form-definition-file-repository.ts
+++ b/src/driven/persistence/form-definition-file-repository.ts
@@ -42,6 +42,7 @@ export class FormDefinitionFileRepository implements FormDefinitionRepository {
     form = this.replaceInForm(form, this.contactpoint, "");
     form = this.replaceInForm(form, this.municipalityMerger, ".");
     form = this.replaceInForm(form, this.language, language);
+    form = this.replaceInForm(form, this.nuts_version, NUTS_VERSION);
     return form;
   }
 


### PR DESCRIPTION
As part of the NUTS/LAU code list update its concept scheme URI was extracted to
a constant to avoid it being specified in multiple places (see #46 and
#50). This required putting a placeholder string in the characteristics form
file, which is overwritten with the actual value when the form file is loaded.

For concept forms the step to overwrite the place holder was not added resulting
in a form that is loaded with the placeholder string stil in it. Since concept
forms are not editable in LPDC this currently does not lead to any issues. This
commit does add the replacement for the placeholder string such that a correct
form is always sent to the frontend. This makes it consistent with other
placeholders that are already replaced and prevents (subtle) bugs should the
concept forms ever become editable.