### PR TITLE
chore: update woodpecker configuration

### DIFF
--- a/.woodpecker/.push-latest-build.yml
+++ b/.woodpecker/.push-latest-build.yml
@@ -18,7 +18,7 @@ steps:
         from_secret: woodpecker_token
 when:
   - event: push
-    branch: [development]
+    branch: [master]
 
 # depends_on:
 #   - test

--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -17,4 +17,4 @@ steps:
       - ssh root@lpdc-dev.s.redhost.be 'cd /data/lpdc-management-service-ci && git fetch && git checkout ${CI_COMMIT_BRANCH} && git pull && cd /data/lpdc-management-service-ci/test && ./run-test.sh'
 when:
   - event: push
-    branch: [development]
+    branch: [master]


### PR DESCRIPTION
In order to bring LPDC more in line with other apps we switch to using the
master branch as primary branch. This PR updates the woodpecker CI to build from the master branch instead of development branch.