### PR TITLE
fix: adjust validations for incomplete authority matches

### DIFF
--- a/src/core/application/validate-instance-for-publish-application-service.ts
+++ b/src/core/application/validate-instance-for-publish-application-service.ts
@@ -283,27 +283,25 @@ export class ValidateInstanceForPublishApplicationService {
     selectedLevels: string[],
     levelsForSelectedAuthorities: string[],
   ): boolean {
-    // Check if every selected level has a matching authority selected with the same level
-    levelsForSelectedAuthorities = levelsForSelectedAuthorities.filter(
+    const validAuthorityLevels = levelsForSelectedAuthorities.filter(
       (level) => level !== undefined,
     );
 
-    // Skip the validation if there are no authorities selected
-    const hasLevelWithoutMatchingAuthority =
-      levelsForSelectedAuthorities.length !== 0 &&
-      selectedLevels.some(
-        (level) => !levelsForSelectedAuthorities.includes(level),
-      );
+    // If either list is empty skip validations
+    if (selectedLevels.length === 0 || validAuthorityLevels.length === 0) {
+      return false;
+    }
 
-    // Check if every selected authority has a matching level selected
-    levelsForSelectedAuthorities = [...new Set(levelsForSelectedAuthorities)];
-    // Skip the validation if there are no levels selected
-    const hasAuthorityWithoutMatchingLevel =
-      selectedLevels.length !== 0 &&
-      levelsForSelectedAuthorities.some(
-        (level) => !selectedLevels.includes(level),
-      );
+    // Check if every selected level has a corresponding authority level or is unmatchable
+    const hasInvalidLevel = selectedLevels.some(
+      (level) => !validAuthorityLevels.includes(level) // not matching
+    );
 
-    return hasLevelWithoutMatchingAuthority || hasAuthorityWithoutMatchingLevel;
+    const hasInvalidAuthority = validAuthorityLevels.some(
+      (authLevel) => !selectedLevels.includes(authLevel) // not matching
+    );
+
+    // Now only return invalid if both sides contain at least one value that does not match
+    return hasInvalidLevel && hasInvalidAuthority;
   }
 }


### PR DESCRIPTION
## ID

LPDC-1429

## Description

Refactored the `hasInvalidAuthorityLevelMapping` function to not block some (incomplete) cases, such as:

Levels: [A, B], Authority levels: [A] → valid
Levels: [A], Authority levels: [A, B] → valid
Levels: [A, B], Authority levels: [A, C] → Invalid (B/C is wrong match)

See ticket for more context:
>When more than one value is filled in in one field (level or organisation), and only one value in the other field (that matches one of the other values) it still gives an error message. 