### PR TITLE
Add Loket-admin as a role

### DIFF
--- a/src/core/domain/session.ts
+++ b/src/core/domain/session.ts
@@ -52,6 +52,7 @@ export class Session {
 
 export enum SessionRoleType {
   LOKETLB_LPDCGEBRUIKER = "LoketLB-LPDCGebruiker",
+  LOKETLB_LPDCADMIN = "LoketLB-admin",
 }
 
 export type SessionRoleTypeOrString = SessionRoleType | string;

--- a/src/driving/sessions.ts
+++ b/src/driving/sessions.ts
@@ -18,7 +18,7 @@ export async function authenticateAndAuthorizeRequest(
     throw new Unauthorized();
   }
   const session = await sessionRepository.findById(sessionId);
-  if (!session.hasRole(SessionRoleType.LOKETLB_LPDCGEBRUIKER)) {
+  if (!(session.hasRole(SessionRoleType.LOKETLB_LPDCGEBRUIKER) || session.hasRole(SessionRoleType.LOKETLB_LPDCADMIN))) {
     throw new Forbidden();
   }
 


### PR DESCRIPTION
When using impersonation in LPDC, allow the LoketLB-admin role to see data.

Logging in as an admin into LPDC, we need to be able to load data as to not crash the application, so that impersonation can be started.