### PR TITLE
[LPDC-1402]: filter out empty contactpoints

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "all"
+}

--- a/src/core/domain/address.ts
+++ b/src/core/domain/address.ts
@@ -136,15 +136,15 @@ export class Address {
   }
 
  public isEmpty(): boolean {
-    const hasGemeentenaam = this._gemeentenaam !== undefined && !this._gemeentenaam.isEmpty();
-    const hasLand = this._land !== undefined && !this._land.isEmpty();
-    const hasHuisnummer = this._huisnummer !== undefined && this._huisnummer.trim() !== '';
-    const hasBusnummer = this._busnummer !== undefined && this._busnummer.trim() !== '';
-    const hasPostcode = this._postcode !== undefined && this._postcode.trim() !== '';
-    const hasStraatnaam = this._straatnaam !== undefined && !this._straatnaam.isEmpty();
-    const hasVerwijstNaar = this._verwijstNaar !== undefined;
+    const hasNoGemeentenaam = this._gemeentenaam === undefined || this._gemeentenaam.isEmpty();
+    const hasNoLand = this._land === undefined || this._land.isEmpty();
+    const hasNoHuisnummer = this._huisnummer === undefined || this._huisnummer.trim() === '';
+    const hasNoBusnummer = this._busnummer === undefined || this._busnummer.trim() === '';
+    const hasNoPostcode = this._postcode === undefined || this._postcode.trim() === '';
+    const hasNoStraatnaam = this._straatnaam === undefined || this._straatnaam.isEmpty();
+    const hasNoVerwijstNaar = this._verwijstNaar === undefined;
 
-    return !hasGemeentenaam && !hasLand && !hasHuisnummer && !hasBusnummer && !hasPostcode && !hasStraatnaam && !hasVerwijstNaar;
+    return hasNoGemeentenaam && hasNoLand && hasNoHuisnummer && hasNoBusnummer && hasNoPostcode && hasNoStraatnaam && hasNoVerwijstNaar;
   }
 }
 

--- a/src/core/domain/address.ts
+++ b/src/core/domain/address.ts
@@ -134,6 +134,18 @@ export class Address {
       .withUuid(uniqueId)
       .build();
   }
+
+ public isEmpty(): boolean {
+    const hasGemeentenaam = this._gemeentenaam !== undefined && !this._gemeentenaam.isEmpty();
+    const hasLand = this._land !== undefined && !this._land.isEmpty();
+    const hasHuisnummer = this._huisnummer !== undefined && this._huisnummer.trim() !== '';
+    const hasBusnummer = this._busnummer !== undefined && this._busnummer.trim() !== '';
+    const hasPostcode = this._postcode !== undefined && this._postcode.trim() !== '';
+    const hasStraatnaam = this._straatnaam !== undefined && !this._straatnaam.isEmpty();
+    const hasVerwijstNaar = this._verwijstNaar !== undefined;
+
+    return !hasGemeentenaam && !hasLand && !hasHuisnummer && !hasBusnummer && !hasPostcode && !hasStraatnaam && !hasVerwijstNaar;
+  }
 }
 
 export class AddressBuilder {

--- a/src/core/domain/contact-point.ts
+++ b/src/core/domain/contact-point.ts
@@ -30,7 +30,7 @@ export class ContactPoint {
     this._telephone = telephone;
     this._openingHours = openingHours;
     this._order = requiredValue(order, "order");
-    this._address = address;
+    this._address = address && !address.isEmpty() ? address : undefined;
   }
 
   static forInstance(contactPoint: ContactPoint): ContactPoint {
@@ -125,8 +125,21 @@ export class ContactPoint {
       .withAddress(this._address?.transformWithNewId())
       .build();
   }
-}
 
+  public isEmpty(): boolean {
+    const hasEmail = this._email !== undefined && this._email.trim() !== "";
+    const hasTelephone =
+      this._telephone !== undefined && this._telephone.trim() !== "";
+    const hasUrl = this._url !== undefined && this._url.trim() !== "";
+    const hasOpeningHours =
+      this._openingHours !== undefined && this._openingHours.trim() !== "";
+    const hasAddress = this._address !== undefined;
+
+    return (
+      !hasUrl && !hasEmail && !hasTelephone && !hasOpeningHours && !hasAddress
+    );
+  }
+}
 export class ContactPointBuilder {
   private id: Iri;
   private uuid: string | undefined;

--- a/src/core/domain/contact-point.ts
+++ b/src/core/domain/contact-point.ts
@@ -127,16 +127,20 @@ export class ContactPoint {
   }
 
   public isEmpty(): boolean {
-    const hasEmail = this._email !== undefined && this._email.trim() !== "";
-    const hasTelephone =
-      this._telephone !== undefined && this._telephone.trim() !== "";
-    const hasUrl = this._url !== undefined && this._url.trim() !== "";
-    const hasOpeningHours =
-      this._openingHours !== undefined && this._openingHours.trim() !== "";
-    const hasAddress = this._address !== undefined;
+    const hasNoEmail = this._email === undefined || this._email.trim() === "";
+    const hasNoTelephone =
+      this._telephone === undefined || this._telephone.trim() === "";
+    const hasNoUrl = this._url === undefined || this._url.trim() === "";
+    const hasNoOpeningHours =
+      this._openingHours === undefined || this._openingHours.trim() === "";
+    const hasNoAddress = this._address === undefined;
 
     return (
-      !hasUrl && !hasEmail && !hasTelephone && !hasOpeningHours && !hasAddress
+      hasNoUrl &&
+      hasNoEmail &&
+      hasNoTelephone &&
+      hasNoOpeningHours &&
+      hasNoAddress
     );
   }
 }

--- a/src/core/domain/instance.ts
+++ b/src/core/domain/instance.ts
@@ -204,7 +204,7 @@ export class Instance {
       this._financialAdvantages.map((fa) => fa.order),
       "financial advantages > order",
     );
-    this._contactPoints = [...contactPoints].map((cp) =>
+    this._contactPoints = [...contactPoints].filter(cp => !cp.isEmpty()).map((cp) =>
       ContactPoint.forInstance(cp),
     );
     requireNoDuplicates(

--- a/src/core/domain/language-string.ts
+++ b/src/core/domain/language-string.ts
@@ -197,4 +197,8 @@ export class LanguageString {
     const strB = b || "";
     return strA.localeCompare(strB);
   }
+
+  public isEmpty(): boolean {
+    return this.notBlankLanguages.length === 0;
+  }
 }

--- a/test/core/domain/instance.unit-test.ts
+++ b/test/core/domain/instance.unit-test.ts
@@ -674,11 +674,11 @@ describe("constructing", () => {
       ).not.toThrow();
     });
 
-    test("invalid contact point does throw error", () => {
+    test("invalid contact point throws error", () => {
       const invalidContactPoint = ContactPoint.reconstitute(
         ContactPointBuilder.buildIri(uuid()),
         undefined,
-        undefined,
+        ContactPointTestBuilder.URL,
         undefined,
         undefined,
         undefined,
@@ -690,11 +690,30 @@ describe("constructing", () => {
       ).toThrow();
     });
 
+    test("empty contact point gets filtered out before creating instance", () => {
+      const uuidValue = uuid();
+      const emptyContactPoint = ContactPoint.reconstitute(
+        ContactPointBuilder.buildIri(uuidValue),
+        uuidValue,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        1,
+        undefined,
+      );
+
+      const result = aFullInstance().withContactPoints([emptyContactPoint]).build();
+      expect(result.contactPoints).toHaveLength(0);
+    });
+
     test("contact points that dont have unique order throws error", () => {
       const contactPoint1 = aMinimalContactPointForInstance()
+        .withUrl(ContactPointTestBuilder.URL)
         .withOrder(1)
         .build();
       const contactPoint2 = aMinimalContactPointForInstance()
+        .withUrl(ContactPointTestBuilder.URL)
         .withOrder(1)
         .build();
 
@@ -765,7 +784,7 @@ describe("constructing", () => {
           Address.reconstitute(
             AddressBuilder.buildIri(uuid()),
             undefined,
-            undefined,
+            aMinimalLanguageString(AddressTestBuilder.GEMEENTENAAM).build(),
             undefined,
             undefined,
             undefined,
@@ -777,6 +796,35 @@ describe("constructing", () => {
         expect(() =>
           aFullInstance().withContactPoints([invalidContactPoint]).build(),
         ).toThrow();
+      });
+
+      test("valid contact point with empty address gets filtered out before creating", () => {
+        const uuidValue = uuid();
+        const uuidValueAddress = uuid();
+        const validContactPoint = ContactPoint.reconstitute(
+          ContactPointBuilder.buildIri(uuidValue),
+          uuidValue,
+          ContactPointTestBuilder.URL,
+          ContactPointTestBuilder.EMAIL,
+          ContactPointTestBuilder.TELEPHONE,
+          ContactPointTestBuilder.OPENING_HOURS,
+          1,
+          Address.reconstitute(
+            AddressBuilder.buildIri(uuidValueAddress),
+            uuidValueAddress,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+          ),
+        );
+
+      const result = aFullInstance().withContactPoints([validContactPoint]).build();
+      expect(result.contactPoints).toHaveLength(1);
+      expect(result.contactPoints[0].address).toBeUndefined();
       });
     });
   });


### PR DESCRIPTION
## ID

LPDC-1402

## Description

Filter out empty contactpoints / addresses before creating. Since these objects don't have *any* required fields they end up getting created as empty objects and pollute the ui/data.

## Testing description

Run in the lpdc stack, create a new instance. Multiple scenarios:
- empty contactpoint -> should not be visible after saving
- empty contactpoint with empty address -> should not be visible after saving
- filled in contactpoint with empty address -> contactpoint should be visible, address should be cleaned up
- filled in conctactpoint with filled in address -> contactpoint and address should remain visible