### PR TITLE
don't change modified date on formal-informal choice

### DIFF
--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -339,24 +339,19 @@ export class InstanceSparqlRepository implements InstanceRepository {
     bestuurseenheid: Bestuurseenheid,
     chosenType: ChosenFormType,
   ) {
-    const now = new Date();
-
     const query = `
         ${PREFIX.lpdcExt}
         WITH ${sparqlEscapeUri(bestuurseenheid.userGraph())}
 
         DELETE {
-           ?instance lpdcExt:needsConversionFromFormalToInformal """false"""^^<http://www.w3.org/2001/XMLSchema#boolean>;
-                     <${NS.schema("dateModified").value}> ?previousDateModified.
+           ?instance lpdcExt:needsConversionFromFormalToInformal """false"""^^<http://www.w3.org/2001/XMLSchema#boolean>.
         }
         INSERT {
-            ?instance lpdcExt:needsConversionFromFormalToInformal """true"""^^<http://www.w3.org/2001/XMLSchema#boolean>;
-                    <${NS.schema("dateModified").value}> ${sparqlEscapeDateTime(now.toISOString())}.
+            ?instance lpdcExt:needsConversionFromFormalToInformal """true"""^^<http://www.w3.org/2001/XMLSchema#boolean>.
         }
         WHERE {
             ?instance a lpdcExt:InstancePublicService;
-                   lpdcExt:dutchLanguageVariant ?variant;
-                   <${NS.schema("dateModified").value}> ?previousDateModified .
+                   lpdcExt:dutchLanguageVariant ?variant.
             FILTER (?variant != "nl-be-x-informal" && CONCAT("nl-be-x-", "${chosenType}") = "nl-be-x-informal")
         }
 


### PR DESCRIPTION
## ID

LPDC-1513

## Description

- When a formal-informal choice is made, some instances are given a “u → je conversion needed” label, this also results in the modified dates being updated. 

- Modified date is changed while there is no content change, only the language label (and u/je-label) are changed.

In order to be able to know when a local authority has updated their information, “technical” updates should not change the date.