### PR TITLE
LPDC-1619 Add MinLenght validation to LPDC

### DIFF
--- a/src/driven/persistence/forms/inhoud/form.ttl
+++ b/src/driven/persistence/forms/inhoud/form.ttl
@@ -68,7 +68,7 @@ ext:basisinformatiePg a form:PropertyGroup;
         sh:path dct:title
       ],
       [
-        a form:MinLength ;
+        a form:TextMinLength ;
         form:grouping form:MatchEvery ;
         form:min "3" ;
         sh:resultMessage "Voeg inhoudelijk relevante informatie toe." ;
@@ -105,7 +105,7 @@ ext:basisinformatiePg a form:PropertyGroup;
         sh:path dct:description
       ],
       [
-        a form:MinLength ;
+        a form:TextMinLength ;
         form:grouping form:MatchEvery ;
         form:min "3" ;
         sh:resultMessage "Voeg inhoudelijk relevante informatie toe." ;
@@ -255,7 +255,7 @@ ext:requirementHeading a form:Field;
           sh:path dct:title
         ],
         [
-          a form:MinLength ;
+          a form:TextMinLength ;
           form:grouping form:MatchEvery ;
           form:min "3" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -292,7 +292,7 @@ ext:requirementHeading a form:Field;
           sh:path dct:description
         ],
         [
-          a form:MinLength ;
+          a form:TextMinLength ;
           form:grouping form:MatchEvery ;
           form:min "3" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -392,7 +392,7 @@ ext:requirementHeading a form:Field;
                 sh:path dct:title
               ],
               [
-                a form:MinLength ;
+                a form:TextMinLength ;
                 form:grouping form:MatchEvery ;
                 form:min "3" ;
                 sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -429,7 +429,7 @@ ext:requirementHeading a form:Field;
                 sh:path dct:description
               ],
               [
-                a form:MinLength ;
+                a form:TextMinLength ;
                 form:grouping form:MatchEvery ;
                 form:min "3" ;
                 sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -525,7 +525,7 @@ ext:rulesHeading a form:Field;
           sh:path dct:title
         ],
         [
-          a form:MinLength ;
+          a form:TextMinLength ;
           form:grouping form:MatchEvery ;
           form:min "3" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -562,7 +562,7 @@ ext:rulesHeading a form:Field;
           sh:path dct:description
         ],
         [
-          a form:MinLength ;
+          a form:TextMinLength ;
           form:grouping form:MatchEvery ;
           form:min "3" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -662,7 +662,7 @@ ext:rulesHeading a form:Field;
                 sh:path dct:title
               ],
               [
-                a form:MinLength ;
+                a form:TextMinLength ;
                 form:grouping form:MatchEvery ;
                 form:min "3" ;
                 sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -805,7 +805,7 @@ ext:costsHeading a form:Field;
           sh:path dct:title
         ],
         [
-          a form:MinLength ;
+          a form:TextMinLength ;
           form:grouping form:MatchEvery ;
           form:min "3" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -836,7 +836,7 @@ ext:costsHeading a form:Field;
           sh:path dct:description
         ],
         [
-          a form:MinLength ;
+          a form:TextMinLength ;
           form:grouping form:MatchEvery ;
           form:min "3" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -935,7 +935,7 @@ ext:finAdvHeading a form:Field;
           sh:path dct:title
         ],
         [
-          a form:MinLength ;
+          a form:TextMinLength ;
           form:grouping form:MatchEvery ;
           form:min "3" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -966,7 +966,7 @@ ext:finAdvHeading a form:Field;
           sh:path dct:description
         ],
         [
-          a form:MinLength ;
+          a form:TextMinLength ;
           form:grouping form:MatchEvery ;
           form:min "3" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
@@ -1436,7 +1436,7 @@ ext:websitesHeading a form:Field;
           sh:path dct:title
         ],
         [
-          a form:MinLength ;
+          a form:TextMinLength ;
           form:grouping form:MatchEvery ;
           form:min "3" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;

--- a/src/driven/persistence/forms/inhoud/form.ttl
+++ b/src/driven/persistence/forms/inhoud/form.ttl
@@ -66,6 +66,14 @@ ext:basisinformatiePg a form:PropertyGroup;
         form:grouping form:Bag ;
         sh:resultMessage "Dit veld is verplicht." ;
         sh:path dct:title
+      ],
+      [
+        a form:MinLength ;
+        form:grouping form:MatchEvery ;
+        form:min "3" ;
+        sh:resultMessage "Voeg inhoudelijk relevante informatie toe." ;
+        sh:severity sh:Warning ;
+        sh:path dct:title
       ];
       form:help "Kies een titel die duidelijk is voor de beoogde doelgroep." ;
       form:options """

--- a/src/driven/persistence/forms/inhoud/form.ttl
+++ b/src/driven/persistence/forms/inhoud/form.ttl
@@ -103,6 +103,14 @@ ext:basisinformatiePg a form:PropertyGroup;
         form:grouping form:Bag ;
         sh:resultMessage "Dit veld bevat ongeldige URL's of email-adressen" ;
         sh:path dct:description
+      ],
+      [
+        a form:MinLength ;
+        form:grouping form:MatchEvery ;
+        form:min "3" ;
+        sh:resultMessage "Voeg inhoudelijk relevante informatie toe." ;
+        sh:severity sh:Warning ;
+        sh:path dct:description
       ];
       sh:path dct:description ;
       form:help "Geef de essentie van de dienstverlening weer in enkele zinnen." ;
@@ -245,6 +253,14 @@ ext:requirementHeading a form:Field;
           form:grouping form:Bag ;
           sh:resultMessage "Dit veld is verplicht." ;
           sh:path dct:title
+        ],
+        [
+          a form:MinLength ;
+          form:grouping form:MatchEvery ;
+          form:min "3" ;
+          sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+          sh:severity sh:Warning ;
+          sh:path dct:title
         ];
         sh:path dct:title ;
         form:options """
@@ -273,6 +289,14 @@ ext:requirementHeading a form:Field;
           a form:RichTextLinkValidator ;
           form:grouping form:Bag ;
           sh:resultMessage "Dit veld bevat ongeldige URL's of email-adressen" ;
+          sh:path dct:description
+        ],
+        [
+          a form:MinLength ;
+          form:grouping form:MatchEvery ;
+          form:min "3" ;
+          sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+          sh:severity sh:Warning ;
           sh:path dct:description
         ];
         sh:path dct:description ;
@@ -366,6 +390,14 @@ ext:requirementHeading a form:Field;
                 form:grouping form:Bag ;
                 sh:resultMessage "Dit veld is verplicht." ;
                 sh:path dct:title
+              ],
+              [
+                a form:MinLength ;
+                form:grouping form:MatchEvery ;
+                form:min "3" ;
+                sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+                sh:severity sh:Warning ;
+                sh:path dct:title
               ];
               sh:path dct:title ;
               form:options """
@@ -394,6 +426,14 @@ ext:requirementHeading a form:Field;
                 a form:RichTextLinkValidator ;
                 form:grouping form:Bag ;
                 sh:resultMessage "Dit veld bevat ongeldige URL's of email-adressen" ;
+                sh:path dct:description
+              ],
+              [
+                a form:MinLength ;
+                form:grouping form:MatchEvery ;
+                form:min "3" ;
+                sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+                sh:severity sh:Warning ;
                 sh:path dct:description
               ];
               sh:path dct:description ;
@@ -483,6 +523,14 @@ ext:rulesHeading a form:Field;
           form:grouping form:Bag ;
           sh:resultMessage "Dit veld is verplicht." ;
           sh:path dct:title
+        ],
+        [
+          a form:MinLength ;
+          form:grouping form:MatchEvery ;
+          form:min "3" ;
+          sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+          sh:severity sh:Warning ;
+          sh:path dct:title
         ];
         sh:path dct:title ;
         form:options """
@@ -511,6 +559,14 @@ ext:rulesHeading a form:Field;
           a form:RichTextLinkValidator ;
           form:grouping form:Bag ;
           sh:resultMessage "Dit veld bevat ongeldige URL's of email-adressen" ;
+          sh:path dct:description
+        ],
+        [
+          a form:MinLength ;
+          form:grouping form:MatchEvery ;
+          form:min "3" ;
+          sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+          sh:severity sh:Warning ;
           sh:path dct:description
         ];
         sh:path dct:description ;
@@ -603,6 +659,14 @@ ext:rulesHeading a form:Field;
                 form:language "<FORMAL_INFORMAL_LANGUAGE>";
                 form:grouping form:Bag ;
                 sh:resultMessage "Dit veld is verplicht." ;
+                sh:path dct:title
+              ],
+              [
+                a form:MinLength ;
+                form:grouping form:MatchEvery ;
+                form:min "3" ;
+                sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+                sh:severity sh:Warning ;
                 sh:path dct:title
               ];
               sh:path dct:title ;
@@ -739,6 +803,14 @@ ext:costsHeading a form:Field;
           form:grouping form:Bag ;
           sh:resultMessage "Dit veld is verplicht." ;
           sh:path dct:title
+        ],
+        [
+          a form:MinLength ;
+          form:grouping form:MatchEvery ;
+          form:min "3" ;
+          sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+          sh:severity sh:Warning ;
+          sh:path dct:title
         ];
         sh:order 1 ;
         sh:path dct:title ;
@@ -761,6 +833,14 @@ ext:costsHeading a form:Field;
           a form:RichTextLinkValidator ;
           form:grouping form:Bag ;
           sh:resultMessage "Dit veld bevat ongeldige URL's of email-adressen" ;
+          sh:path dct:description
+        ],
+        [
+          a form:MinLength ;
+          form:grouping form:MatchEvery ;
+          form:min "3" ;
+          sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+          sh:severity sh:Warning ;
           sh:path dct:description
         ];
         sh:order 3 ;
@@ -853,6 +933,14 @@ ext:finAdvHeading a form:Field;
           form:grouping form:Bag ;
           sh:resultMessage "Dit veld is verplicht." ;
           sh:path dct:title
+        ],
+        [
+          a form:MinLength ;
+          form:grouping form:MatchEvery ;
+          form:min "3" ;
+          sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+          sh:severity sh:Warning ;
+          sh:path dct:title
         ];
         sh:order 1 ;
         sh:path dct:title ;
@@ -875,6 +963,14 @@ ext:finAdvHeading a form:Field;
           a form:RichTextLinkValidator ;
           form:grouping form:Bag ;
           sh:resultMessage "Dit veld bevat ongeldige URL's of email-adressen" ;
+          sh:path dct:description
+        ],
+        [
+          a form:MinLength ;
+          form:grouping form:MatchEvery ;
+          form:min "3" ;
+          sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+          sh:severity sh:Warning ;
           sh:path dct:description
         ];
         sh:order 3 ;
@@ -1337,6 +1433,14 @@ ext:websitesHeading a form:Field;
           form:language "<FORMAL_INFORMAL_LANGUAGE>";
           form:grouping form:Bag ;
           sh:resultMessage "Dit veld is verplicht." ;
+          sh:path dct:title
+        ],
+        [
+          a form:MinLength ;
+          form:grouping form:MatchEvery ;
+          form:min "3" ;
+          sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
+          sh:severity sh:Warning ;
           sh:path dct:title
         ];
         sh:path dct:title ;

--- a/src/driven/persistence/forms/inhoud/form.ttl
+++ b/src/driven/persistence/forms/inhoud/form.ttl
@@ -70,7 +70,7 @@ ext:basisinformatiePg a form:PropertyGroup;
       [
         a form:TextMinLength ;
         form:grouping form:MatchEvery ;
-        form:min "3" ;
+        form:min "4" ;
         sh:resultMessage "Voeg inhoudelijk relevante informatie toe." ;
         sh:severity sh:Warning ;
         sh:path dct:title
@@ -107,7 +107,7 @@ ext:basisinformatiePg a form:PropertyGroup;
       [
         a form:TextMinLength ;
         form:grouping form:MatchEvery ;
-        form:min "3" ;
+        form:min "4" ;
         sh:resultMessage "Voeg inhoudelijk relevante informatie toe." ;
         sh:severity sh:Warning ;
         sh:path dct:description
@@ -257,7 +257,7 @@ ext:requirementHeading a form:Field;
         [
           a form:TextMinLength ;
           form:grouping form:MatchEvery ;
-          form:min "3" ;
+          form:min "4" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
           sh:severity sh:Warning ;
           sh:path dct:title
@@ -294,7 +294,7 @@ ext:requirementHeading a form:Field;
         [
           a form:TextMinLength ;
           form:grouping form:MatchEvery ;
-          form:min "3" ;
+          form:min "4" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
           sh:severity sh:Warning ;
           sh:path dct:description
@@ -394,7 +394,7 @@ ext:requirementHeading a form:Field;
               [
                 a form:TextMinLength ;
                 form:grouping form:MatchEvery ;
-                form:min "3" ;
+                form:min "4" ;
                 sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
                 sh:severity sh:Warning ;
                 sh:path dct:title
@@ -431,7 +431,7 @@ ext:requirementHeading a form:Field;
               [
                 a form:TextMinLength ;
                 form:grouping form:MatchEvery ;
-                form:min "3" ;
+                form:min "4" ;
                 sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
                 sh:severity sh:Warning ;
                 sh:path dct:description
@@ -527,7 +527,7 @@ ext:rulesHeading a form:Field;
         [
           a form:TextMinLength ;
           form:grouping form:MatchEvery ;
-          form:min "3" ;
+          form:min "4" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
           sh:severity sh:Warning ;
           sh:path dct:title
@@ -564,7 +564,7 @@ ext:rulesHeading a form:Field;
         [
           a form:TextMinLength ;
           form:grouping form:MatchEvery ;
-          form:min "3" ;
+          form:min "4" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
           sh:severity sh:Warning ;
           sh:path dct:description
@@ -664,7 +664,7 @@ ext:rulesHeading a form:Field;
               [
                 a form:TextMinLength ;
                 form:grouping form:MatchEvery ;
-                form:min "3" ;
+                form:min "4" ;
                 sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
                 sh:severity sh:Warning ;
                 sh:path dct:title
@@ -807,7 +807,7 @@ ext:costsHeading a form:Field;
         [
           a form:TextMinLength ;
           form:grouping form:MatchEvery ;
-          form:min "3" ;
+          form:min "4" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
           sh:severity sh:Warning ;
           sh:path dct:title
@@ -838,7 +838,7 @@ ext:costsHeading a form:Field;
         [
           a form:TextMinLength ;
           form:grouping form:MatchEvery ;
-          form:min "3" ;
+          form:min "4" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
           sh:severity sh:Warning ;
           sh:path dct:description
@@ -937,7 +937,7 @@ ext:finAdvHeading a form:Field;
         [
           a form:TextMinLength ;
           form:grouping form:MatchEvery ;
-          form:min "3" ;
+          form:min "4" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
           sh:severity sh:Warning ;
           sh:path dct:title
@@ -968,7 +968,7 @@ ext:finAdvHeading a form:Field;
         [
           a form:TextMinLength ;
           form:grouping form:MatchEvery ;
-          form:min "3" ;
+          form:min "4" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
           sh:severity sh:Warning ;
           sh:path dct:description
@@ -1438,7 +1438,7 @@ ext:websitesHeading a form:Field;
         [
           a form:TextMinLength ;
           form:grouping form:MatchEvery ;
-          form:min "3" ;
+          form:min "4" ;
           sh:resultMessage "Voeg inhoudelijk relevante informatie toe, of verwijder deze groep velden via de verwijderknop." ;
           sh:severity sh:Warning ;
           sh:path dct:title


### PR DESCRIPTION
- Added MinLength validation to the right fields in the form

**Ticket**
LPDC-1619

**Test:**
See if by typing:

- No characters → Only get the validation “dit veld is verplicht”
- 3 characters or less → Get the warning message. See ticket for messages per field. 

They should appear in all ‘Verplicht’ fields (except for the URL ones, because you already get the url validation if you type 3 characters or less)