### PR TITLE
LPDC-1088: herziening nodig fixes

### DIFF
--- a/src/core/domain/language-string.ts
+++ b/src/core/domain/language-string.ts
@@ -150,10 +150,15 @@ export class LanguageString {
     value: LanguageString | undefined,
     other: LanguageString | undefined,
   ): boolean {
+    const valueFormal = value?.nlFormal ?? value?.nlGeneratedFormal;
+    const otherFormal = other?.nlFormal ?? other?.nlGeneratedFormal;
+    const valueInformal = value?.nlInformal ?? value?.nlGeneratedInformal;
+    const otherInformal = other?.nlInformal ?? other?.nlGeneratedInformal;
+
     return (
       value?.nl !== other?.nl ||
-      value?.nlFormal !== other?.nlFormal ||
-      value?.nlInformal !== other?.nlInformal
+      valueFormal !== otherFormal ||
+      valueInformal !== otherInformal
     );
   }
 

--- a/src/core/domain/language-string.ts
+++ b/src/core/domain/language-string.ts
@@ -147,6 +147,7 @@ export class LanguageString {
   }
 
   static isFunctionallyChanged(
+// Compares language strings using effective values. Switching between generated and explicit values with identical content is not a meaningful change and should not count as a functional difference.
     value: LanguageString | undefined,
     other: LanguageString | undefined,
   ): boolean {

--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -317,6 +317,25 @@ export class InstanceSparqlRepository implements InstanceRepository {
                 }
             }`;
       await this.querying.deleteInsert(updateReviewStatusesQuery);
+    } else {
+      const removeReviewStatusQuery = `
+            ${PREFIX.ext}
+            ${PREFIX.lpdcExt}
+            ${PREFIX.dct}
+
+            DELETE {
+                GRAPH ?g {
+                    ?service ext:reviewStatus ?status.
+                }
+            }
+            WHERE {
+                GRAPH ?g {
+                    ?service a lpdcExt:InstancePublicService;
+                        dct:source ${sparqlEscapeUri(conceptId)}.
+                    ?service ext:reviewStatus ?status.
+                }
+            }`;
+      await this.querying.deleteInsert(removeReviewStatusQuery);
     }
   }
 


### PR DESCRIPTION
Added a query for if the new conceptSnapShot doesnt have any differences with the current conceptSnapShot. If this is the case, and there is still a herziening nodig label on that concept, it will delete it

The voorwaarde change makes sure that it doesn´t show a change if the only change in the concept is that it has a nl-formal instead of nl-generated-formal (or informal).

### Ticket
LPDC-1088

### To test
1. Simulate a new conceptSnapShot appearing in lpdc
2. See if the herziening nodig is gone if no difference
