### PR TITLE
Add the ABB classification code

### DIFF
--- a/src/core/domain/bestuurseenheid.ts
+++ b/src/core/domain/bestuurseenheid.ts
@@ -105,6 +105,7 @@ export enum BestuurseenheidClassificatieCode {
   WELZIJNSVERENIGING = "Welzijnsvereniging",
   OCMW_VERENIGING = "OCMW vereniging",
   VLAAMSE_GEMEENSCHAPSCOMMISSIE = "Vlaamse gemeenschapscommissie",
+  ABB = "Agentschap Binnenlands Bestuur",
 }
 
 export enum BestuurseenheidStatusCode {

--- a/src/core/domain/language-string.ts
+++ b/src/core/domain/language-string.ts
@@ -147,7 +147,7 @@ export class LanguageString {
   }
 
   static isFunctionallyChanged(
-// Compares language strings using effective values. Switching between generated and explicit values with identical content is not a meaningful change and should not count as a functional difference.
+    // Compares language strings using effective values. Switching between generated and explicit values with identical content is not a meaningful change and should not count as a functional difference.
     value: LanguageString | undefined,
     other: LanguageString | undefined,
   ): boolean {

--- a/src/driven/persistence/bestuurseenheid-sparql-repository.ts
+++ b/src/driven/persistence/bestuurseenheid-sparql-repository.ts
@@ -158,6 +158,7 @@ export enum BestuurseenheidClassificatieCodeUri {
   WELZIJNSVERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9",
   OCMW_VERENIGING = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089",
   VLAAMSE_GEMEENSCHAPSCOMMISSIE = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d90c511e-f827-488c-84ba-432c8f69561c",
+  ABB = "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/52cc9d8d-1c9a-4d92-9936-da9d4a622ec4",
 }
 
 export enum BestuurseenheidStatusCodeUri {


### PR DESCRIPTION
## ID

LPDC-1644

## Description

Added the ABB classification code, this will stop the errors popping up when logged in as ABB to impersonate  or to check the dashboard. The errors in the logs and UI are confusing and put us on a false path sometimes when something is broken..

logs error:
```
lpdc-management-1  | 2026-04-17T08:27:40.781647697Z   stackTrace: 'Error: Geen classificatiecode gevonden voor: http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/52cc9d8d-1c9a-4d92-9936-da9d4a622ec4\n' +
```

UI error:
<img width="337" height="330" alt="image" src="https://github.com/user-attachments/assets/6b0630e4-96f6-4e93-886d-2d51dd74a673" />


## How to test

Run in the lpdc stack, log in as `Agentschap binnenlands bestuur` org in the frontend. The error should not appear anymore.