### PR TITLE
LPDC-1638: Herziening nodig label data fix

### DIFF
--- a/migration-scripts/herziening-nodig-delete/.env-example
+++ b/migration-scripts/herziening-nodig-delete/.env-example
@@ -1,0 +1,1 @@
+SPARQL_URL="http://localhost:8890/sparql"

--- a/migration-scripts/herziening-nodig-delete/herziening-nodig-delete.ts
+++ b/migration-scripts/herziening-nodig-delete/herziening-nodig-delete.ts
@@ -12,7 +12,9 @@ const directDb = new DirectDatabaseAccess(endPoint);
 const sparqlQuerying = new SparqlQuerying(endPoint);
 const snapshotRepo = new ConceptSnapshotSparqlRepository(endPoint);
 
-async function getAllInstancesWithReviewStatus(): Promise<{ id: Iri; conceptId: Iri; upToDateSnapshotId: Iri }[]> {
+async function getAllInstancesWithReviewStatus(): Promise<
+  { id: Iri; conceptId: Iri; upToDateSnapshotId: Iri }[]
+> {
   const query = `
     ${PREFIX.lpdcExt}
     ${PREFIX.dct}
@@ -30,7 +32,7 @@ async function getAllInstancesWithReviewStatus(): Promise<{ id: Iri; conceptId: 
 
   const results = await directDb.list(query);
 
-  return (results as any[]).map(r => ({
+  return (results as any[]).map((r) => ({
     id: new Iri(r.id.value),
     conceptId: new Iri(r.conceptId.value),
     upToDateSnapshotId: new Iri(r.upToDateSnapshotId.value),
@@ -90,15 +92,21 @@ async function main() {
   for (const instance of instances) {
     const latestSnapshotId = await getLatestSnapshotId(instance.conceptId);
     if (!latestSnapshotId) {
-      console.log(`No latest snapshot found for concept ${instance.conceptId.value}, skipping`);
+      console.log(
+        `No latest snapshot found for concept ${instance.conceptId.value}, skipping`,
+      );
       continue;
     }
 
-    const upToDateSnapshot = await snapshotRepo.findById(instance.upToDateSnapshotId);
+    const upToDateSnapshot = await snapshotRepo.findById(
+      instance.upToDateSnapshotId,
+    );
     const latestSnapshot = await snapshotRepo.findById(latestSnapshotId);
 
     const isArchived = latestSnapshot.isArchived;
-    const isFunctionallyChanged = ConceptSnapshot.isFunctionallyChanged(upToDateSnapshot, latestSnapshot).length !== 0;
+    const isFunctionallyChanged =
+      ConceptSnapshot.isFunctionallyChanged(upToDateSnapshot, latestSnapshot)
+        .length !== 0;
 
     if (!isArchived && !isFunctionallyChanged) {
       console.log(`Removing review status from instance ${instance.id.value}`);
@@ -112,7 +120,7 @@ async function main() {
 
 main()
   .then(() => process.exit(0))
-  .catch(err => {
+  .catch((err) => {
     console.error(err);
     process.exit(1);
   });

--- a/migration-scripts/herziening-nodig-delete/herziening-nodig-delete.ts
+++ b/migration-scripts/herziening-nodig-delete/herziening-nodig-delete.ts
@@ -1,0 +1,118 @@
+import { DirectDatabaseAccess } from "../../test/driven/persistence/direct-database-access";
+import { SparqlQuerying } from "../../src/driven/persistence/sparql-querying";
+import { ConceptSnapshot } from "../../src/core/domain/concept-snapshot";
+import { ConceptSnapshotSparqlRepository } from "../../src/driven/persistence/concept-snapshot-sparql-repository";
+import { Iri } from "../../src/core/domain/shared/iri";
+import { PREFIX } from "../../config";
+import { sparqlEscapeUri } from "../../mu-helper";
+
+const endPoint = process.env.SPARQL_URL!;
+
+const directDb = new DirectDatabaseAccess(endPoint);
+const sparqlQuerying = new SparqlQuerying(endPoint);
+const snapshotRepo = new ConceptSnapshotSparqlRepository(endPoint);
+
+async function getAllInstancesWithReviewStatus(): Promise<{ id: Iri; conceptId: Iri; upToDateSnapshotId: Iri }[]> {
+  const query = `
+    ${PREFIX.lpdcExt}
+    ${PREFIX.dct}
+    ${PREFIX.ext}
+
+    SELECT ?id ?conceptId ?upToDateSnapshotId WHERE {
+      GRAPH ?g {
+        ?id a lpdcExt:InstancePublicService ;
+            dct:source ?conceptId ;
+            ext:reviewStatus ?status ;
+            ext:hasVersionedSource ?upToDateSnapshotId .
+      }
+    }
+  `;
+
+  const results = await directDb.list(query);
+
+  return (results as any[]).map(r => ({
+    id: new Iri(r.id.value),
+    conceptId: new Iri(r.conceptId.value),
+    upToDateSnapshotId: new Iri(r.upToDateSnapshotId.value),
+  }));
+}
+
+async function getLatestSnapshotId(conceptId: Iri): Promise<Iri | undefined> {
+  const query = `
+    ${PREFIX.lpdcExt}
+    ${PREFIX.dct}
+    ${PREFIX.prov}
+
+    SELECT ?snapshotId WHERE {
+      GRAPH ?g {
+        ?snapshotId a lpdcExt:ConceptualPublicServiceSnapshot ;
+                    dct:isVersionOf ${sparqlEscapeUri(conceptId)} ;
+                    prov:generatedAtTime ?time .
+      }
+    }
+    ORDER BY DESC(?time)
+    LIMIT 1
+  `;
+
+  const results = await directDb.list(query);
+  if ((results as any[]).length === 0) return undefined;
+  return new Iri((results as any[])[0].snapshotId.value);
+}
+
+async function removeReviewStatus(instanceId: Iri) {
+  const query = `
+    ${PREFIX.ext}
+    ${PREFIX.lpdcExt}
+
+    DELETE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(instanceId)} ext:reviewStatus ?status.
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(instanceId)} a lpdcExt:InstancePublicService ;
+                 ext:reviewStatus ?status .
+      }
+    }
+  `;
+
+  await sparqlQuerying.deleteInsert(query);
+}
+
+async function main() {
+  const instances = await getAllInstancesWithReviewStatus();
+
+  console.log(`Found ${instances.length} instances with review status`);
+
+  let removed = 0;
+
+  for (const instance of instances) {
+    const latestSnapshotId = await getLatestSnapshotId(instance.conceptId);
+    if (!latestSnapshotId) {
+      console.log(`No latest snapshot found for concept ${instance.conceptId.value}, skipping`);
+      continue;
+    }
+
+    const upToDateSnapshot = await snapshotRepo.findById(instance.upToDateSnapshotId);
+    const latestSnapshot = await snapshotRepo.findById(latestSnapshotId);
+
+    const isArchived = latestSnapshot.isArchived;
+    const isFunctionallyChanged = ConceptSnapshot.isFunctionallyChanged(upToDateSnapshot, latestSnapshot).length !== 0;
+
+    if (!isArchived && !isFunctionallyChanged) {
+      console.log(`Removing review status from instance ${instance.id.value}`);
+      await removeReviewStatus(instance.id);
+      removed++;
+    }
+  }
+
+  console.log(`Done. Removed review status from ${removed} instances.`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/migration-scripts/herziening-nodig-delete/package-lock.json
+++ b/migration-scripts/herziening-nodig-delete/package-lock.json
@@ -1,0 +1,269 @@
+{
+  "name": "herziening-nodig-restore",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "herziening-nodig-restore",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^17.4.2",
+        "node-fetch": "^2.7.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/migration-scripts/herziening-nodig-delete/package.json
+++ b/migration-scripts/herziening-nodig-delete/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "herziening-nodig-restore",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "ts-node -r dotenv/config herziening-nodig-restore.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "dotenv": "^17.4.2",
+    "node-fetch": "^2.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^6.0.3"
+  }
+}

--- a/migration-scripts/herziening-nodig-delete/package.json
+++ b/migration-scripts/herziening-nodig-delete/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "ts-node -r dotenv/config herziening-nodig-restore.ts"
+    "start": "ts-node -r dotenv/config herziening-nodig-delete.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
We need to be able to delete incorrect herziening nodig labels, since we did not do this before, and now there are instances that have it, but don't need it. This migration script does this.

**To test:**
- Get a dev backup, Bilzen-Hoestelt quite a few instances with herziening nodig. An incorrect one is " Horecavergunning voor specifieke doelgroep"
- Go to the lpdc-management-service and then to herziening-nodig-restore
- Run the script 
- Check if the incorrect instance is gone, and the other ones are still there.

You can also run the script from app-lpdc-digitaal-loket with
`docker compose exec lpdc-management sh -c "cd /app/migration-scripts/herziening-nodig-delete && SPARQL_URL=http://virtuoso:8890/sparql npm start"`

**Ticket**
LPDC-1638