### PR TITLE
LPDC-1661: trim url's when ingesting snapshots

### DIFF
--- a/src/driven/shared/quads-to-domain-mapper.ts
+++ b/src/driven/shared/quads-to-domain-mapper.ts
@@ -669,10 +669,11 @@ export class QuadsToDomainMapper {
   }
 
   private url(id: Iri): string | undefined {
-    return this.storeAccess.uniqueValue(
+    const urlValue = this.storeAccess.uniqueValue(
       this.asNamedOrBlankNode(id),
       NS.schema("url"),
     );
+    return urlValue?.trim();
   }
 
   private firstName(id: Iri): string | undefined {


### PR DESCRIPTION
- Added trimming for urls that arrive via ldes feed snapshots

TO TEST:
- rysnc 
- remove processed marker from a snapshot that contains a website with url containing trailing spaces (or first edit so that it contains trailing spaces)
- lpdc-management cron should start processing this snapshot again
- check that trailing spaces are removed in org graphs
