### PR TITLE
LPDC-1650: Herziening nodig afzetten voor update u/je-omzetting bij IPDC

### DIFF
--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -48,7 +48,7 @@ export class InstanceSparqlRepository implements InstanceRepository {
       this.doubleQuadReporter = doubleQuadReporter;
     }
     this.reviewStatusUpdatesEnabled =
-      process.env.ENABLE_REVIEW_STATUS_UPDATES !== "false";
+      process.env.DISABLE_REVIEW_STATUS_UPDATES !== "true";
   }
 
   async findById(bestuurseenheid: Bestuurseenheid, id: Iri): Promise<Instance> {

--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -39,6 +39,7 @@ export class InstanceSparqlRepository implements InstanceRepository {
   protected readonly fetcher: DatastoreToQuadsRecursiveSparqlFetcher;
   protected doubleQuadReporter: DoubleQuadReporter =
     new LoggingDoubleQuadReporter(new Logger("Instance-QuadsToDomainLogger"));
+  private readonly reviewStatusUpdatesEnabled: boolean;
 
   constructor(endpoint?: string, doubleQuadReporter?: DoubleQuadReporter) {
     this.querying = new SparqlQuerying(endpoint);
@@ -46,6 +47,8 @@ export class InstanceSparqlRepository implements InstanceRepository {
     if (doubleQuadReporter) {
       this.doubleQuadReporter = doubleQuadReporter;
     }
+    this.reviewStatusUpdatesEnabled =
+      process.env.ENABLE_REVIEW_STATUS_UPDATES !== "false";
   }
 
   async findById(bestuurseenheid: Bestuurseenheid, id: Iri): Promise<Instance> {
@@ -284,6 +287,9 @@ export class InstanceSparqlRepository implements InstanceRepository {
     isConceptFunctionallyChanged: boolean,
     isConceptArchived: boolean,
   ): Promise<void> {
+    if (!this.reviewStatusUpdatesEnabled) {
+      return;
+    }
     let reviewStatus = undefined;
     if (isConceptArchived) {
       reviewStatus = InstanceReviewStatusType.CONCEPT_GEARCHIVEERD;

--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -287,6 +287,7 @@ export class InstanceSparqlRepository implements InstanceRepository {
     isConceptFunctionallyChanged: boolean,
     isConceptArchived: boolean,
   ): Promise<void> {
+    // Disables the "Herziening nodig" process via DISABLE_REVIEW_STATUS_UPDATES: "true" in app-lpdc-digitaal-loket docker-compose.override.
     if (!this.reviewStatusUpdatesEnabled) {
       return;
     }


### PR DESCRIPTION
Added an option to turn off herziening nodig

### Test

1. Simulate a new conceptSnapShot appearing in lpdc
3. See if the herziening nodig is not there if you set the ENABLE_REVIEW_STATUS_UPDATES in the override in app-lpdc-management
4. See if the herziening nodig stays if you set it to true. 

Also need: https://github.com/lblod/app-lpdc-digitaal-loket/pull/101