### PR TITLE
LPDC-1662 Keep track of herziening/u-je changes for notification service

### DIFF
--- a/src/core/domain/instance.ts
+++ b/src/core/domain/instance.ts
@@ -69,6 +69,8 @@ export class Instance {
   private readonly _needsConversionFromFormalToInformal: boolean;
   private readonly _dateCreated: FormatPreservingDate;
   private readonly _dateModified: FormatPreservingDate;
+  private readonly _revisionModifiedDate: FormatPreservingDate;
+  private readonly _formalInformalModifiedDate: FormatPreservingDate;
   private readonly _creator: Iri;
   private readonly _lastModifier: Iri;
   private readonly _dateSent: FormatPreservingDate | undefined;
@@ -114,6 +116,8 @@ export class Instance {
     needsConversionFromFormalToInformal: boolean,
     dateCreated: FormatPreservingDate,
     dateModified: FormatPreservingDate,
+    revisionModifiedDate: FormatPreservingDate | undefined,
+    formalInformalModifiedDate: FormatPreservingDate | undefined,
     creator: Iri,
     lastModifier: Iri,
     dateSent: FormatPreservingDate | undefined,
@@ -233,6 +237,8 @@ export class Instance {
     );
     this._dateCreated = requiredValue(dateCreated, "dateCreated");
     this._dateModified = requiredValue(dateModified, "dateModified");
+    this._revisionModifiedDate = revisionModifiedDate;
+    this._formalInformalModifiedDate = formalInformalModifiedDate;
     // No required values, because existing instances won't have a creator
     this._creator = creator;
     this._lastModifier = lastModifier;
@@ -490,6 +496,14 @@ export class Instance {
     return this._dateModified;
   }
 
+  get revisionModifiedDate(): FormatPreservingDate {
+    return this._revisionModifiedDate;
+  }
+
+  get formalInformalModifiedDate(): FormatPreservingDate {
+    return this._formalInformalModifiedDate;
+  }
+
   get creator(): Iri {
     return this._creator;
   }
@@ -634,6 +648,8 @@ export class InstanceBuilder {
   private needsConversionFromFormalToInformal: boolean;
   private dateCreated: FormatPreservingDate;
   private dateModified: FormatPreservingDate;
+  private revisionModifiedDate: FormatPreservingDate;
+  private formalInformalModifiedDate: FormatPreservingDate;
   private creator: Iri;
   private lastModifier: Iri;
   private dateSent: FormatPreservingDate | undefined;
@@ -686,6 +702,8 @@ export class InstanceBuilder {
       )
       .withDateCreated(instance.dateCreated)
       .withDateModified(instance.dateModified)
+      .withRevisionModifiedDate(instance.revisionModifiedDate)
+      .withFormalInformalModifiedDate(instance.formalInformalModifiedDate)
       .withCreator(instance.creator)
       .withLastModifier(instance.lastModifier)
       .withDateSent(instance.dateSent)
@@ -890,6 +908,16 @@ export class InstanceBuilder {
     return this;
   }
 
+  public withRevisionModifiedDate(revisionModifiedDate: FormatPreservingDate): InstanceBuilder {
+    this.revisionModifiedDate = revisionModifiedDate;
+    return this;
+  }
+
+  public withFormalInformalModifiedDate(formalInformalModifiedDate: FormatPreservingDate): InstanceBuilder {
+  this.formalInformalModifiedDate = formalInformalModifiedDate;
+  return this;
+}
+
   public withCreator(user: Iri): InstanceBuilder {
     this.creator = user;
     return this;
@@ -975,6 +1003,8 @@ export class InstanceBuilder {
       this.needsConversionFromFormalToInformal,
       this.dateCreated,
       this.dateModified,
+      this.revisionModifiedDate,
+      this.formalInformalModifiedDate,
       this.creator,
       this.lastModifier,
       this.dateSent,

--- a/src/core/domain/instance.ts
+++ b/src/core/domain/instance.ts
@@ -908,15 +908,19 @@ export class InstanceBuilder {
     return this;
   }
 
-  public withRevisionModifiedDate(revisionModifiedDate: FormatPreservingDate): InstanceBuilder {
+  public withRevisionModifiedDate(
+    revisionModifiedDate: FormatPreservingDate,
+  ): InstanceBuilder {
     this.revisionModifiedDate = revisionModifiedDate;
     return this;
   }
 
-  public withFormalInformalModifiedDate(formalInformalModifiedDate: FormatPreservingDate): InstanceBuilder {
-  this.formalInformalModifiedDate = formalInformalModifiedDate;
-  return this;
-}
+  public withFormalInformalModifiedDate(
+    formalInformalModifiedDate: FormatPreservingDate,
+  ): InstanceBuilder {
+    this.formalInformalModifiedDate = formalInformalModifiedDate;
+    return this;
+  }
 
   public withCreator(user: Iri): InstanceBuilder {
     this.creator = user;

--- a/src/core/domain/instance.ts
+++ b/src/core/domain/instance.ts
@@ -702,7 +702,7 @@ export class InstanceBuilder {
       )
       .withDateCreated(instance.dateCreated)
       .withDateModified(instance.dateModified)
-      .withRevisionModifiedDate(instance.reviewStatusModifiedDate)
+      .withReviewStatusModifiedDate(instance.reviewStatusModifiedDate)
       .withFormalInformalModifiedDate(instance.formalInformalModifiedDate)
       .withCreator(instance.creator)
       .withLastModifier(instance.lastModifier)
@@ -908,7 +908,7 @@ export class InstanceBuilder {
     return this;
   }
 
-  public withRevisionModifiedDate(
+  public withReviewStatusModifiedDate(
     reviewStatusModifiedDate: FormatPreservingDate,
   ): InstanceBuilder {
     this.reviewStatusModifiedDate = reviewStatusModifiedDate;

--- a/src/core/domain/instance.ts
+++ b/src/core/domain/instance.ts
@@ -69,7 +69,7 @@ export class Instance {
   private readonly _needsConversionFromFormalToInformal: boolean;
   private readonly _dateCreated: FormatPreservingDate;
   private readonly _dateModified: FormatPreservingDate;
-  private readonly _revisionModifiedDate: FormatPreservingDate;
+  private readonly _reviewStatusModifiedDate: FormatPreservingDate;
   private readonly _formalInformalModifiedDate: FormatPreservingDate;
   private readonly _creator: Iri;
   private readonly _lastModifier: Iri;
@@ -116,7 +116,7 @@ export class Instance {
     needsConversionFromFormalToInformal: boolean,
     dateCreated: FormatPreservingDate,
     dateModified: FormatPreservingDate,
-    revisionModifiedDate: FormatPreservingDate | undefined,
+    reviewStatusModifiedDate: FormatPreservingDate | undefined,
     formalInformalModifiedDate: FormatPreservingDate | undefined,
     creator: Iri,
     lastModifier: Iri,
@@ -237,7 +237,7 @@ export class Instance {
     );
     this._dateCreated = requiredValue(dateCreated, "dateCreated");
     this._dateModified = requiredValue(dateModified, "dateModified");
-    this._revisionModifiedDate = revisionModifiedDate;
+    this._reviewStatusModifiedDate = reviewStatusModifiedDate;
     this._formalInformalModifiedDate = formalInformalModifiedDate;
     // No required values, because existing instances won't have a creator
     this._creator = creator;
@@ -496,8 +496,8 @@ export class Instance {
     return this._dateModified;
   }
 
-  get revisionModifiedDate(): FormatPreservingDate {
-    return this._revisionModifiedDate;
+  get reviewStatusModifiedDate(): FormatPreservingDate {
+    return this._reviewStatusModifiedDate;
   }
 
   get formalInformalModifiedDate(): FormatPreservingDate {
@@ -648,7 +648,7 @@ export class InstanceBuilder {
   private needsConversionFromFormalToInformal: boolean;
   private dateCreated: FormatPreservingDate;
   private dateModified: FormatPreservingDate;
-  private revisionModifiedDate: FormatPreservingDate;
+  private reviewStatusModifiedDate: FormatPreservingDate;
   private formalInformalModifiedDate: FormatPreservingDate;
   private creator: Iri;
   private lastModifier: Iri;
@@ -702,7 +702,7 @@ export class InstanceBuilder {
       )
       .withDateCreated(instance.dateCreated)
       .withDateModified(instance.dateModified)
-      .withRevisionModifiedDate(instance.revisionModifiedDate)
+      .withRevisionModifiedDate(instance.reviewStatusModifiedDate)
       .withFormalInformalModifiedDate(instance.formalInformalModifiedDate)
       .withCreator(instance.creator)
       .withLastModifier(instance.lastModifier)
@@ -909,9 +909,9 @@ export class InstanceBuilder {
   }
 
   public withRevisionModifiedDate(
-    revisionModifiedDate: FormatPreservingDate,
+    reviewStatusModifiedDate: FormatPreservingDate,
   ): InstanceBuilder {
-    this.revisionModifiedDate = revisionModifiedDate;
+    this.reviewStatusModifiedDate = reviewStatusModifiedDate;
     return this;
   }
 
@@ -1007,7 +1007,7 @@ export class InstanceBuilder {
       this.needsConversionFromFormalToInformal,
       this.dateCreated,
       this.dateModified,
-      this.revisionModifiedDate,
+      this.reviewStatusModifiedDate,
       this.formalInformalModifiedDate,
       this.creator,
       this.lastModifier,

--- a/src/core/domain/new-instance-domain-service.ts
+++ b/src/core/domain/new-instance-domain-service.ts
@@ -88,6 +88,8 @@ export class NewInstanceDomainService {
       false,
       now,
       now,
+      undefined,
+      undefined,
       user,
       user,
       undefined,
@@ -194,6 +196,8 @@ export class NewInstanceDomainService {
       false,
       now,
       now,
+      undefined,
+      undefined,
       user,
       user,
       undefined,
@@ -247,6 +251,8 @@ export class NewInstanceDomainService {
       )
       .withDateCreated(FormatPreservingDate.now())
       .withDateModified(FormatPreservingDate.now())
+      .withRevisionModifiedDate(undefined)
+      .withFormalInformalModifiedDate(undefined)
       .withCreator(user)
       .withLastModifier(user)
       .withRequirements(

--- a/src/core/domain/new-instance-domain-service.ts
+++ b/src/core/domain/new-instance-domain-service.ts
@@ -251,7 +251,7 @@ export class NewInstanceDomainService {
       )
       .withDateCreated(FormatPreservingDate.now())
       .withDateModified(FormatPreservingDate.now())
-      .withRevisionModifiedDate(undefined)
+      .withReviewStatusModifiedDate(undefined)
       .withFormalInformalModifiedDate(undefined)
       .withCreator(user)
       .withLastModifier(user)

--- a/src/driven/persistence/domain-to-quads-mapper.ts
+++ b/src/driven/persistence/domain-to-quads-mapper.ts
@@ -231,7 +231,7 @@ export class DomainToQuadsMapper {
       ),
       this.dateCreated(instance.id, instance.dateCreated),
       this.dateModified(instance.id, instance.dateModified),
-      this.revisionModifiedDate(instance.id, instance.revisionModifiedDate),
+      this.reviewStatusModifiedDate(instance.id, instance.reviewStatusModifiedDate),
       this.formalInformalModifiedDate(
         instance.id,
         instance.formalInformalModifiedDate,
@@ -529,14 +529,14 @@ export class DomainToQuadsMapper {
       : undefined;
   }
 
-  private revisionModifiedDate(
+  private reviewStatusModifiedDate(
     id: Iri,
     value: FormatPreservingDate | undefined,
   ) {
     return value
       ? this.buildQuad(
           namedNode(id.value),
-          NS.lpdcExt("revisionModifiedDate"),
+          NS.lpdcExt("reviewStatusModifiedDate"),
           literal(value.value, NS.xsd("dateTime")),
         )
       : undefined;

--- a/src/driven/persistence/domain-to-quads-mapper.ts
+++ b/src/driven/persistence/domain-to-quads-mapper.ts
@@ -231,6 +231,8 @@ export class DomainToQuadsMapper {
       ),
       this.dateCreated(instance.id, instance.dateCreated),
       this.dateModified(instance.id, instance.dateModified),
+      this.revisionModifiedDate(instance.id, instance.revisionModifiedDate),
+      this.formalInformalModifiedDate(instance.id, instance.formalInformalModifiedDate),
       this.creator(instance.id, instance.creator),
       this.lastModifier(instance.id, instance.lastModifier),
       instance.dateSent
@@ -524,6 +526,26 @@ export class DomainToQuadsMapper {
       : undefined;
   }
 
+  private revisionModifiedDate(id: Iri, value: FormatPreservingDate | undefined ) {
+    return value
+      ? this.buildQuad(
+          namedNode(id.value),
+          NS.lpdcExt("revisionModifiedDate"),
+          literal(value.value, NS.xsd("dateTime")),
+        )
+      : undefined;
+  }
+
+  private formalInformalModifiedDate(id: Iri, value: FormatPreservingDate | undefined ) {
+    return value
+      ? this.buildQuad(
+          namedNode(id.value),
+          NS.lpdcExt("formalInformalModifiedDate"),
+          literal(value.value, NS.xsd("dateTime")),
+        )
+      : undefined;
+  }
+  
   private dateModified(id: Iri, value: FormatPreservingDate | undefined) {
     return value
       ? this.buildQuad(

--- a/src/driven/persistence/domain-to-quads-mapper.ts
+++ b/src/driven/persistence/domain-to-quads-mapper.ts
@@ -231,7 +231,10 @@ export class DomainToQuadsMapper {
       ),
       this.dateCreated(instance.id, instance.dateCreated),
       this.dateModified(instance.id, instance.dateModified),
-      this.reviewStatusModifiedDate(instance.id, instance.reviewStatusModifiedDate),
+      this.reviewStatusModifiedDate(
+        instance.id,
+        instance.reviewStatusModifiedDate,
+      ),
       this.formalInformalModifiedDate(
         instance.id,
         instance.formalInformalModifiedDate,

--- a/src/driven/persistence/domain-to-quads-mapper.ts
+++ b/src/driven/persistence/domain-to-quads-mapper.ts
@@ -232,7 +232,10 @@ export class DomainToQuadsMapper {
       this.dateCreated(instance.id, instance.dateCreated),
       this.dateModified(instance.id, instance.dateModified),
       this.revisionModifiedDate(instance.id, instance.revisionModifiedDate),
-      this.formalInformalModifiedDate(instance.id, instance.formalInformalModifiedDate),
+      this.formalInformalModifiedDate(
+        instance.id,
+        instance.formalInformalModifiedDate,
+      ),
       this.creator(instance.id, instance.creator),
       this.lastModifier(instance.id, instance.lastModifier),
       instance.dateSent
@@ -526,7 +529,10 @@ export class DomainToQuadsMapper {
       : undefined;
   }
 
-  private revisionModifiedDate(id: Iri, value: FormatPreservingDate | undefined ) {
+  private revisionModifiedDate(
+    id: Iri,
+    value: FormatPreservingDate | undefined,
+  ) {
     return value
       ? this.buildQuad(
           namedNode(id.value),
@@ -536,7 +542,10 @@ export class DomainToQuadsMapper {
       : undefined;
   }
 
-  private formalInformalModifiedDate(id: Iri, value: FormatPreservingDate | undefined ) {
+  private formalInformalModifiedDate(
+    id: Iri,
+    value: FormatPreservingDate | undefined,
+  ) {
     return value
       ? this.buildQuad(
           namedNode(id.value),
@@ -545,7 +554,7 @@ export class DomainToQuadsMapper {
         )
       : undefined;
   }
-  
+
   private dateModified(id: Iri, value: FormatPreservingDate | undefined) {
     return value
       ? this.buildQuad(

--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -309,13 +309,13 @@ export class InstanceSparqlRepository implements InstanceRepository {
             DELETE {
                 GRAPH ?g {
                     ?service ext:reviewStatus ?status;
-                             lpdcExt:revisionModifiedDate ?oldDate
+                             lpdcExt:reviewStatusModifiedDate ?oldDate
                 }
             }
             INSERT {
                 GRAPH ?g {
                     ?service ext:reviewStatus ${NS.concepts.reviewStatus(reviewStatus)};
-                             lpdcExt:revisionModifiedDate ${sparqlEscapeDateTime(now.toISOString())}.
+                             lpdcExt:reviewStatusModifiedDate ${sparqlEscapeDateTime(now.toISOString())}.
                 }
             }
             WHERE {
@@ -326,7 +326,7 @@ export class InstanceSparqlRepository implements InstanceRepository {
                         ?service ext:reviewStatus ?status.
                     }
                     OPTIONAL {
-                        ?service lpdcExt:revisionModifiedDate ?oldDate .
+                        ?service lpdcExt:reviewStatusModifiedDate ?oldDate .
                     }    
                 }
             }`;

--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -365,19 +365,28 @@ export class InstanceSparqlRepository implements InstanceRepository {
     bestuurseenheid: Bestuurseenheid,
     chosenType: ChosenFormType,
   ) {
+    const now = new Date();
+
     const query = `
         ${PREFIX.lpdcExt}
         WITH ${sparqlEscapeUri(bestuurseenheid.userGraph())}
 
         DELETE {
-           ?instance lpdcExt:needsConversionFromFormalToInformal """false"""^^<http://www.w3.org/2001/XMLSchema#boolean>.
+          ?instance lpdcExt:needsConversionFromFormalToInformal """false"""^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+                    lpdcExt:formalInformalModifiedDate ?old .
         }
         INSERT {
-            ?instance lpdcExt:needsConversionFromFormalToInformal """true"""^^<http://www.w3.org/2001/XMLSchema#boolean>.
+            ?instance lpdcExt:needsConversionFromFormalToInformal """true"""^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+                    lpdcExt:formalInformalModifiedDate ${sparqlEscapeDateTime(now.toISOString())} .
         }
         WHERE {
             ?instance a lpdcExt:InstancePublicService;
                    lpdcExt:dutchLanguageVariant ?variant.
+            
+            OPTIONAL {
+                ?instance lpdcExt:formalInformalModifiedDate ?old .
+            }
+
             FILTER (?variant != "nl-be-x-informal" && CONCAT("nl-be-x-", "${chosenType}") = "nl-be-x-informal")
         }
 

--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -299,6 +299,8 @@ export class InstanceSparqlRepository implements InstanceRepository {
     }
 
     if (reviewStatus) {
+      const now = new Date();
+
       const updateReviewStatusesQuery = `
             ${PREFIX.ext}
             ${PREFIX.lpdcExt}
@@ -306,12 +308,14 @@ export class InstanceSparqlRepository implements InstanceRepository {
 
             DELETE {
                 GRAPH ?g {
-                    ?service ext:reviewStatus ?status.
+                    ?service ext:reviewStatus ?status;
+                             lpdcExt:revisionModifiedDate ?oldDate
                 }
             }
             INSERT {
                 GRAPH ?g {
-                    ?service ext:reviewStatus ${NS.concepts.reviewStatus(reviewStatus)}.
+                    ?service ext:reviewStatus ${NS.concepts.reviewStatus(reviewStatus)};
+                             lpdcExt:revisionModifiedDate ${sparqlEscapeDateTime(now.toISOString())}.
                 }
             }
             WHERE {
@@ -321,6 +325,9 @@ export class InstanceSparqlRepository implements InstanceRepository {
                     OPTIONAL {
                         ?service ext:reviewStatus ?status.
                     }
+                    OPTIONAL {
+                        ?service lpdcExt:revisionModifiedDate ?oldDate .
+                    }    
                 }
             }`;
       await this.querying.deleteInsert(updateReviewStatusesQuery);

--- a/src/driven/shared/quads-to-domain-mapper.ts
+++ b/src/driven/shared/quads-to-domain-mapper.ts
@@ -380,7 +380,7 @@ export class QuadsToDomainMapper {
       this.needsConversionFromFormalToInformal(id),
       this.dateCreated(id),
       this.dateModified(id),
-      this.revisionModifiedDate(id),
+      this.reviewStatusModifiedDate(id),
       this.formalInformalModifiedDate(id),
       this.creator(id),
       this.lastModifier(id),
@@ -718,11 +718,11 @@ export class QuadsToDomainMapper {
     );
   }
 
-  revisionModifiedDate(id: Iri): FormatPreservingDate | undefined {
+  reviewStatusModifiedDate(id: Iri): FormatPreservingDate | undefined {
     return this.asFormatPreservingDate(
       this.storeAccess.uniqueValue(
         this.asNamedOrBlankNode(id),
-        NS.lpdcExt("revisionModifiedDate"),
+        NS.lpdcExt("reviewStatusModifiedDate"),
       ),
     );
   }

--- a/src/driven/shared/quads-to-domain-mapper.ts
+++ b/src/driven/shared/quads-to-domain-mapper.ts
@@ -380,6 +380,8 @@ export class QuadsToDomainMapper {
       this.needsConversionFromFormalToInformal(id),
       this.dateCreated(id),
       this.dateModified(id),
+      this.revisionModifiedDate(id),
+      this.formalInformalModifiedDate(id),
       this.creator(id),
       this.lastModifier(id),
       this.dateSent(id),
@@ -712,6 +714,24 @@ export class QuadsToDomainMapper {
       this.storeAccess.uniqueValue(
         this.asNamedOrBlankNode(id),
         NS.schema("dateModified"),
+      ),
+    );
+  }
+
+  revisionModifiedDate(id: Iri): FormatPreservingDate | undefined {
+    return this.asFormatPreservingDate(
+      this.storeAccess.uniqueValue(
+        this.asNamedOrBlankNode(id),
+        NS.lpdcExt("revisionModifiedDate"),
+      ),
+    );
+  }
+
+  formalInformalModifiedDate(id: Iri): FormatPreservingDate | undefined {
+    return this.asFormatPreservingDate(
+      this.storeAccess.uniqueValue(
+        this.asNamedOrBlankNode(id),
+        NS.lpdcExt("formalInformalModifiedDate"),
       ),
     );
   }


### PR DESCRIPTION
Adding 2 new fields, formalInformalModifiedDate and revisionModifiedDate

### Status
- [x] u/je first version
- [x] herziening first version

### Testing (using dev data)
**For u-je modified date:**

1. Go to a bestuurseenheid without a u/je choice yet (Hooglede)
2. Dont choose and make an u instance
3. Go back, login via Hooglede again in mock-login and choose "je"
4. See if you can find the triple.

**For herziening nodig**
1. Simulate a herziening nodig (new snapshot appearing with new changes)
2. See if you can find the triple

### Ticket
LPDC-1662