### PR TITLE
[LPDC-1692]: fix broken delete regex when 'nothing to do', blocking concept ingestion

### DIFF
--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -327,7 +327,7 @@ export class InstanceSparqlRepository implements InstanceRepository {
                     }
                     OPTIONAL {
                         ?service lpdcExt:reviewStatusModifiedDate ?oldDate .
-                    }    
+                    }
                 }
             }`;
       await this.querying.deleteInsert(updateReviewStatusesQuery);
@@ -349,7 +349,7 @@ export class InstanceSparqlRepository implements InstanceRepository {
                     ?service ext:reviewStatus ?status.
                 }
             }`;
-      await this.querying.deleteInsert(removeReviewStatusQuery);
+      await this.querying.delete(removeReviewStatusQuery);
     }
   }
 
@@ -389,7 +389,7 @@ export class InstanceSparqlRepository implements InstanceRepository {
         WHERE {
             ?instance a lpdcExt:InstancePublicService;
                    lpdcExt:dutchLanguageVariant ?variant.
-            
+
             OPTIONAL {
                 ?instance lpdcExt:formalInformalModifiedDate ?old .
             }

--- a/src/driven/persistence/sparql-querying.ts
+++ b/src/driven/persistence/sparql-querying.ts
@@ -32,7 +32,7 @@ export class SparqlQuerying {
     this.verifyResultToMatch(
       query,
       result,
-      /Delete from <.*>, \d+ \(or less\) (triples|quads) -- done/,
+      /Delete from <.*>, \d+ (\(or less\) )?(triples|quads) (-- done|-- nothing to do)/,
     );
   }
 


### PR DESCRIPTION
## ID

LPDC-1692

## Description

There was an edge case in the [previous PR](https://github.com/lblod/lpdc-management-service/pull/84/changes) that clears the reviewStatus.

If a concept comes in but has no previous versions, it will hit the else and try to clear the reviewStatus. But because there aren't any the `verifyResultToMatch` of deleteInsert throws an error and the processing flow stops. Which is why the `ConceptDisplayConfiguration` doesn't get created, as well as a missing 'nieuw' pill.

To fix this I've:
- switched from `deleteInsert` to `delete` (since there aren't any inserts anyway)
- updated the `verifyResultToMatch` regex to handle the case of `nothing to do`

Alternatively we could also add a check to see if we need to delete a reviewStatus but I think this is more efficient. Let me know if you have other ideas.

## Testing
 
I tested by letting Geertrui create a new concept via IPDC and ingesting locally, I think you previously had a query to create a new concept as well, otherwise ask Geertrui to create another one (if you backup the /data folder before the ingestion you can reproduce as much as you want)

The concept should now come in and get processed without throwing an erorr. You should be able to immediately create an instance from the concept.