### PR TITLE
[LPDC-1693]: cleanup notificationPreference when deleting an instance

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -13,6 +13,7 @@ import { ConceptSparqlRepository } from "./src/driven/persistence/concept-sparql
 import { Iri } from "./src/core/domain/shared/iri";
 import { ConceptSnapshotToConceptMergerDomainService } from "./src/core/domain/concept-snapshot-to-concept-merger-domain-service";
 import { ConceptDisplayConfigurationSparqlRepository } from "./src/driven/persistence/concept-display-configuration-sparql-repository";
+import { NotificationPreferenceSparqlRepository } from "./src/driven/persistence/notification-preference-sparql-repository";
 import { BestuurseenheidRegistrationCodeThroughSubjectPageOrApiFetcher } from "./src/driven/external/bestuurseenheid-registration-code-through-subject-page-or-api-fetcher";
 import { CodeSparqlRepository } from "./src/driven/persistence/code-sparql-repository";
 import { InstanceSparqlRepository } from "./src/driven/persistence/instance-sparql-repository";
@@ -70,6 +71,8 @@ const conceptSnapshotRepository = new ConceptSnapshotSparqlRepository();
 const conceptRepository = new ConceptSparqlRepository();
 const conceptDisplayConfigurationRepository =
   new ConceptDisplayConfigurationSparqlRepository();
+const notificationPreferenceRepository =
+  new NotificationPreferenceSparqlRepository();
 const bestuurseenheidRegistrationCodeFetcher =
   new BestuurseenheidRegistrationCodeThroughSubjectPageOrApiFetcher();
 const codeRepository = new CodeSparqlRepository();
@@ -119,6 +122,7 @@ const newInstanceDomainService = new NewInstanceDomainService(
 const deleteInstanceDomainService = new DeleteInstanceDomainService(
   instanceRepository,
   conceptDisplayConfigurationRepository,
+  notificationPreferenceRepository,
 );
 
 const formApplicationService = new FormApplicationService(

--- a/src/core/domain/delete-instance-domain-service.ts
+++ b/src/core/domain/delete-instance-domain-service.ts
@@ -1,5 +1,6 @@
 import { InstanceRepository } from "../port/driven/persistence/instance-repository";
 import { ConceptDisplayConfigurationRepository } from "../port/driven/persistence/concept-display-configuration-repository";
+import { NotificationPreferenceRepository } from "../port/driven/persistence/notification-preference-repository";
 import { Bestuurseenheid } from "./bestuurseenheid";
 import { Iri } from "./shared/iri";
 import { FormatPreservingDate } from "./format-preserving-date";
@@ -7,14 +8,17 @@ import { FormatPreservingDate } from "./format-preserving-date";
 export class DeleteInstanceDomainService {
   private readonly _instanceRepository: InstanceRepository;
   private readonly _conceptDisplayConfigurationRepository: ConceptDisplayConfigurationRepository;
+  private readonly _notificationPreferenceRepository: NotificationPreferenceRepository;
 
   constructor(
     instanceRepository: InstanceRepository,
     conceptDisplayConfigurationRepository: ConceptDisplayConfigurationRepository,
+    notificationPreferenceRepository: NotificationPreferenceRepository,
   ) {
     this._instanceRepository = instanceRepository;
     this._conceptDisplayConfigurationRepository =
       conceptDisplayConfigurationRepository;
+    this._notificationPreferenceRepository = notificationPreferenceRepository;
   }
 
   public async delete(
@@ -38,6 +42,12 @@ export class DeleteInstanceDomainService {
         instance.conceptId,
       );
     }
+
+    // Cleanup all notificationPreference links to the instance
+    await this._notificationPreferenceRepository.removeNotificationInstance(
+      bestuurseenheid,
+      instance.id,
+    );
     return tombstoneIdOrUndefined;
   }
 }

--- a/src/core/domain/delete-instance-domain-service.ts
+++ b/src/core/domain/delete-instance-domain-service.ts
@@ -30,6 +30,13 @@ export class DeleteInstanceDomainService {
       bestuurseenheid,
       instanceId,
     );
+
+    // Cleanup all notificationPreference links to the instance
+    await this._notificationPreferenceRepository.removeNotificationInstanceLink(
+      bestuurseenheid,
+      instance.id,
+    );
+
     const tombstoneIdOrUndefined = await this._instanceRepository.delete(
       bestuurseenheid,
       instance.id,
@@ -42,12 +49,6 @@ export class DeleteInstanceDomainService {
         instance.conceptId,
       );
     }
-
-    // Cleanup all notificationPreference links to the instance
-    await this._notificationPreferenceRepository.removeNotificationInstance(
-      bestuurseenheid,
-      instance.id,
-    );
     return tombstoneIdOrUndefined;
   }
 }

--- a/src/core/port/driven/persistence/notification-preference-repository.ts
+++ b/src/core/port/driven/persistence/notification-preference-repository.ts
@@ -2,5 +2,5 @@ import { Iri } from "../../../domain/shared/iri";
 import { Bestuurseenheid } from "../../../domain/bestuurseenheid";
 
 export interface NotificationPreferenceRepository {
-  removeNotificationInstance(bestuurseenheid: Bestuurseenheid, instanceId: Iri)
+  removeNotificationInstance(bestuurseenheid: Bestuurseenheid, instanceId: Iri);
 }

--- a/src/core/port/driven/persistence/notification-preference-repository.ts
+++ b/src/core/port/driven/persistence/notification-preference-repository.ts
@@ -2,5 +2,8 @@ import { Iri } from "../../../domain/shared/iri";
 import { Bestuurseenheid } from "../../../domain/bestuurseenheid";
 
 export interface NotificationPreferenceRepository {
-  removeNotificationInstance(bestuurseenheid: Bestuurseenheid, instanceId: Iri);
+  removeNotificationInstanceLink(
+    bestuurseenheid: Bestuurseenheid,
+    instanceId: Iri,
+  );
 }

--- a/src/core/port/driven/persistence/notification-preference-repository.ts
+++ b/src/core/port/driven/persistence/notification-preference-repository.ts
@@ -1,0 +1,6 @@
+import { Iri } from "../../../domain/shared/iri";
+import { Bestuurseenheid } from "../../../domain/bestuurseenheid";
+
+export interface NotificationPreferenceRepository {
+  removeNotificationInstance(bestuurseenheid: Bestuurseenheid, instanceId: Iri)
+}

--- a/src/driven/persistence/notification-preference-sparql-repository.ts
+++ b/src/driven/persistence/notification-preference-sparql-repository.ts
@@ -1,0 +1,34 @@
+import { NotificationPreferenceRepository } from "../../core/port/driven/persistence/notification-preference-repository";
+import { Iri } from "../../core/domain/shared/iri";
+import { SparqlQuerying } from "./sparql-querying";
+import { Bestuurseenheid } from "../../core/domain/bestuurseenheid";
+import { PREFIX } from "../../../config";
+import { sparqlEscapeUri } from "../../../mu-helper";
+
+export class NotificationPreferenceSparqlRepository
+  implements NotificationPreferenceRepository
+{
+  protected readonly querying: SparqlQuerying;
+
+  constructor(endpoint?: string) {
+    this.querying = new SparqlQuerying(endpoint);
+  }
+
+  async removeNotificationInstance(
+    bestuurseenheid: Bestuurseenheid,
+    instanceId: Iri,
+  ) {
+    const query = `
+        ${PREFIX.lpdcExt}
+        WITH ${sparqlEscapeUri(bestuurseenheid.userGraph())}
+        DELETE {
+          ?preference lpdcExt:notificationInstance ${sparqlEscapeUri(instanceId.value)} .
+        }
+        WHERE {
+          ?preference a lpdcExt:NotificationPreference ;
+                      lpdcExt:notificationInstance ${sparqlEscapeUri(instanceId.value)} .
+        }`;
+
+    await this.querying.delete(query);
+  }
+}

--- a/src/driven/persistence/notification-preference-sparql-repository.ts
+++ b/src/driven/persistence/notification-preference-sparql-repository.ts
@@ -14,7 +14,7 @@ export class NotificationPreferenceSparqlRepository
     this.querying = new SparqlQuerying(endpoint);
   }
 
-  async removeNotificationInstance(
+  async removeNotificationInstanceLink(
     bestuurseenheid: Bestuurseenheid,
     instanceId: Iri,
   ) {

--- a/test/core/application/instance-snapshot-processor-application-service.it-test.ts
+++ b/test/core/application/instance-snapshot-processor-application-service.it-test.ts
@@ -47,7 +47,7 @@ describe("InstanceSnapshotProcessorApplicationService", () => {
   const deleteInstanceDomainService = new DeleteInstanceDomainService(
     instanceRepository,
     conceptDisplayConfigurationRepository,
-    notificationPreferenceRepository
+    notificationPreferenceRepository,
   );
   const bestuurseenheidRegistrationCodeFetcher = {
     fetchOrgRegistryCodelistEntry: jest

--- a/test/core/application/instance-snapshot-processor-application-service.it-test.ts
+++ b/test/core/application/instance-snapshot-processor-application-service.it-test.ts
@@ -22,6 +22,7 @@ import { VersionedLdesSnapshotSparqlRepository } from "../../../src/driven/persi
 import { InstanceSparqlRepository } from "../../../src/driven/persistence/instance-sparql-repository";
 import spyOn = jest.spyOn;
 import { SpatialSparqlRepository } from "../../../src/driven/persistence/spatial-sparql-repository";
+import { NotificationPreferenceSparqlRepository } from "../../../src/driven/persistence/notification-preference-sparql-repository";
 
 describe("InstanceSnapshotProcessorApplicationService", () => {
   beforeEach(async () => {
@@ -38,12 +39,15 @@ describe("InstanceSnapshotProcessorApplicationService", () => {
   const conceptRepository = new ConceptSparqlRepository(TEST_SPARQL_ENDPOINT);
   const conceptDisplayConfigurationRepository =
     new ConceptDisplayConfigurationSparqlTestRepository(TEST_SPARQL_ENDPOINT);
+  const notificationPreferenceRepository =
+    new NotificationPreferenceSparqlRepository(TEST_SPARQL_ENDPOINT);
 
   const spatialRepository = new SpatialSparqlRepository(TEST_SPARQL_ENDPOINT);
 
   const deleteInstanceDomainService = new DeleteInstanceDomainService(
     instanceRepository,
     conceptDisplayConfigurationRepository,
+    notificationPreferenceRepository
   );
   const bestuurseenheidRegistrationCodeFetcher = {
     fetchOrgRegistryCodelistEntry: jest

--- a/test/core/domain/delete-instance-domain-service.unit-test.ts
+++ b/test/core/domain/delete-instance-domain-service.unit-test.ts
@@ -12,6 +12,7 @@ import { restoreRealTime, setFixedTime } from "../../fixed-time";
 import { NotFoundError } from "../../../src/core/domain/shared/lpdc-error";
 import { InstanceBuilder } from "../../../src/core/domain/instance";
 import { InstanceSparqlRepository } from "../../../src/driven/persistence/instance-sparql-repository";
+import { NotificationPreferenceSparqlRepository } from "../../../src/driven/persistence/notification-preference-sparql-repository";
 
 describe("Deleting a new Instance domain service", () => {
   const instanceRepository = new InstanceSparqlRepository(TEST_SPARQL_ENDPOINT);
@@ -20,10 +21,13 @@ describe("Deleting a new Instance domain service", () => {
     new ConceptDisplayConfigurationSparqlRepository(TEST_SPARQL_ENDPOINT);
   const conceptDisplayConfigurationSparqlTestRepository =
     new ConceptDisplayConfigurationSparqlTestRepository(TEST_SPARQL_ENDPOINT);
+  const notificationPreferenceSparqlRepository =
+    new NotificationPreferenceSparqlRepository(TEST_SPARQL_ENDPOINT);
 
   const deleteInstanceDomainService = new DeleteInstanceDomainService(
     instanceRepository,
     conceptDisplayConfigurationSparqlRepository,
+    notificationPreferenceSparqlRepository,
   );
 
   beforeAll(() => setFixedTime());

--- a/test/core/domain/instance-snapshot-to-instance-merger-domain-service.it-test.ts
+++ b/test/core/domain/instance-snapshot-to-instance-merger-domain-service.it-test.ts
@@ -67,6 +67,7 @@ import {
   anExpiredSpatial,
 } from "./spatial-test-builder";
 import { SpatialSparqlTestRepository } from "../../driven/persistence/spatial-sparql-test-repository";
+import { NotificationPreferenceSparqlRepository } from "../../../src/driven/persistence/notification-preference-sparql-repository";
 
 describe("instanceSnapshotToInstanceMapperDomainService", () => {
   beforeEach(async () => {
@@ -103,9 +104,12 @@ describe("instanceSnapshotToInstanceMapperDomainService", () => {
     );
   const conceptDisplayConfigurationRepository =
     new ConceptDisplayConfigurationSparqlRepository(TEST_SPARQL_ENDPOINT);
+  const notificationPreferenceRepository =
+    new NotificationPreferenceSparqlRepository(TEST_SPARQL_ENDPOINT);
   const deleteInstanceDomainService = new DeleteInstanceDomainService(
     instanceRepository,
     conceptDisplayConfigurationRepository,
+    notificationPreferenceRepository
   );
   const instanceSnapshotProcessingAuthorizationRepository =
     new InstanceSnapshotProcessingAuthorizationSparqlTestRepository(
@@ -2262,7 +2266,7 @@ describe("instanceSnapshotToInstanceMapperDomainService", () => {
         const query = `
                     SELECT ?s ?p ?o WHERE {
                         GRAPH ${sparqlEscapeUri(bestuurseenheid.userGraph())} {
-                            VALUES ?s {                         
+                            VALUES ?s {
                                 <${tombstoneId}>
                             }
                             ?s ?p ?o

--- a/test/core/domain/instance-snapshot-to-instance-merger-domain-service.it-test.ts
+++ b/test/core/domain/instance-snapshot-to-instance-merger-domain-service.it-test.ts
@@ -109,7 +109,7 @@ describe("instanceSnapshotToInstanceMapperDomainService", () => {
   const deleteInstanceDomainService = new DeleteInstanceDomainService(
     instanceRepository,
     conceptDisplayConfigurationRepository,
-    notificationPreferenceRepository
+    notificationPreferenceRepository,
   );
   const instanceSnapshotProcessingAuthorizationRepository =
     new InstanceSnapshotProcessingAuthorizationSparqlTestRepository(


### PR DESCRIPTION
## ID

LPDC-1693

## Description

Cleanup all notificationPreferences links to the instance when deleting that instance

## Testing instructions

Setup with backend and TEST data, create notificationPreference and subscribe to an instance. Remove the instance and verify that the notificationPreference no longer has a link to that instance in the data.