### PR TITLE
use database instead of directly virtuoso for reviewStatus & formalInformal to trigger deltanotifier

### DIFF
--- a/src/driven/persistence/instance-sparql-repository.ts
+++ b/src/driven/persistence/instance-sparql-repository.ts
@@ -36,6 +36,7 @@ import { PublishedInstanceSnapshotBuilder } from "../../core/domain/published-in
 
 export class InstanceSparqlRepository implements InstanceRepository {
   protected readonly querying: SparqlQuerying;
+  protected readonly databaseQuerying: SparqlQuerying;
   protected readonly fetcher: DatastoreToQuadsRecursiveSparqlFetcher;
   protected doubleQuadReporter: DoubleQuadReporter =
     new LoggingDoubleQuadReporter(new Logger("Instance-QuadsToDomainLogger"));
@@ -43,6 +44,9 @@ export class InstanceSparqlRepository implements InstanceRepository {
 
   constructor(endpoint?: string, doubleQuadReporter?: DoubleQuadReporter) {
     this.querying = new SparqlQuerying(endpoint);
+    this.databaseQuerying = new SparqlQuerying(
+      process.env.MU_SPARQL_ENDPOINT || "http://database:8890/sparql",
+    );
     this.fetcher = new DatastoreToQuadsRecursiveSparqlFetcher(endpoint);
     if (doubleQuadReporter) {
       this.doubleQuadReporter = doubleQuadReporter;
@@ -330,7 +334,7 @@ export class InstanceSparqlRepository implements InstanceRepository {
                     }
                 }
             }`;
-      await this.querying.deleteInsert(updateReviewStatusesQuery);
+      await this.databaseQuerying.deleteInsert(updateReviewStatusesQuery);
     } else {
       const removeReviewStatusQuery = `
             ${PREFIX.ext}
@@ -398,7 +402,7 @@ export class InstanceSparqlRepository implements InstanceRepository {
         }
 
         `;
-    await this.querying.deleteInsert(query);
+    await this.databaseQuerying.deleteInsert(query);
   }
 
   async isPublishedToIpdc(

--- a/src/driven/persistence/sparql-querying.ts
+++ b/src/driven/persistence/sparql-querying.ts
@@ -48,7 +48,7 @@ export class SparqlQuerying {
     this.verifyResultToMatch(
       query,
       result,
-      /(Modify <.*>, delete \d+ \(or less\) and insert \d+ \(or less\) triples -- done|(Delete \d+ \(or less\) quads -- done)|(Delete from <.*>, 0 quads -- nothing to do)\n(Insert into <.*>, \d+ \(or less\) quads -- done)|(Insert into <.*>, 0 quads -- nothing to do))/,
+      /(Modify <.*>, delete \d+ \(or less\) and insert \d+ \(or less\) triples -- done|(Delete \d+ \(or less\) quads -- done)|(Delete from <.*>, 0 quads -- nothing to do)\n(Insert into <.*>, \d+ \(or less\) quads -- done)|(Insert into <.*>, 0 quads -- nothing to do)|(Executed update query))/,
     );
     if (resultVerification) {
       const results = result.results.bindings.map((b) => b["callret-0"].value);


### PR DESCRIPTION
## ID

LPDC-1699

## Description

The deltanotifier was not being triggered by changes to the formalInformal & reviewStatus because the update queries were being sent directly to virtuoso instead of through the database, thus no instant notifications are being sent.

Updated to use the database for these 2 functions so the problem is solved.

## Testing

Setup local stack with TEST data, in the app.ts add the following function to mock 
```
async function testDeltanotifier(){
  const conceptId = new Iri("https://ipdc.tni-vlaanderen.be/id/concept/38f480a7-0642-43d4-b31b-fc2e5ea02f94");
  await instanceRepository.updateReviewStatusesForInstances(
    conceptId,
    true,   // isConceptFunctionallyChanged
    false,  // isConceptArchived
  );
}
testDeltanotifier()
```